### PR TITLE
Do not render railway crossings if only tramways are involved (#4559).

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2220,7 +2220,6 @@ Layer:
             way,
             name,
             COALESCE(
-              'railway_' || CASE WHEN railway IN ('level_crossing', 'crossing') AND way_area IS NULL THEN railway END,
               'amenity_' || CASE WHEN amenity IN ('bench', 'waste_basket', 'waste_disposal') AND way_area IS NULL THEN amenity END,
               'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') AND way_area IS NULL THEN historic END,
               'man_made_' || CASE WHEN man_made IN ('cross') AND way_area IS NULL THEN man_made END,
@@ -2275,6 +2274,30 @@ Layer:
               END DESC,
               way_pixels DESC NULLS LAST
           ) AS amenity_low_priority
+    properties:
+      cache-features: true
+      minzoom: 14
+# Render railway crossings except if they concern tramways only
+  - id: railway-crossings
+    geometry: point
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: &railway-crossing_sql |-
+        (SELECT DISTINCT ON (crossing.way)
+            'railway_' || crossing.railway AS feature,
+            crossing.way AS way,
+            crossing.access AS access,
+            crossing.railway AS type,
+            crossing.railway AS railway,
+            track.railway AS int_lc_type
+          FROM planet_osm_point crossing
+            JOIN planet_osm_line track
+              ON ST_DWithin(crossing.way, track.way, 0.1) -- Assumes Mercator
+          WHERE crossing.railway IN ('crossing', 'level_crossing')
+            AND track.railway IS NOT NULL AND track.railway <> 'tram'
+          ORDER BY crossing.way
+        ) AS railway_crossing_sql
     properties:
       cache-features: true
       minzoom: 14

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1471,7 +1471,8 @@
   }
 }
 
-#amenity-low-priority {
+#amenity-low-priority,
+#railway-crossings {
   [feature = 'man_made_cross'][zoom >= 16],
   [feature = 'historic_wayside_cross'][zoom >= 16] {
     marker-file: url('symbols/man_made/cross.svg');


### PR DESCRIPTION
Fixes #4559 

Changes proposed in this pull request:
Do not render railway crossings if only tramways are involved. 

Test rendering with links to the example places:

https://www.openstreetmap.org/#map=16/47.5403/7.5733

Before
![grafik](https://user-images.githubusercontent.com/3518185/175913504-fc11d434-f4cb-4086-989b-407983604019.png)


After
![grafik](https://user-images.githubusercontent.com/3518185/175913736-7a82c563-19d3-4d15-b276-0c62f471e15b.png)

