### PR TITLE
Source Arabic font from CDN, newer repo

### DIFF
--- a/scripts/get-fonts.py
+++ b/scripts/get-fonts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # This script downloads several Noto fonts from https://github.com/notofonts/noto-fonts
 # That repo was archived in 2023 and is no longer updated.
-# Additional fonts can be found on https://notofonts.github.io
+# Fonts in the NEWER_REPO list are downloaded from Noto's CDN or individual repos.
 
 import os
 import requests
@@ -17,13 +17,19 @@ try:
 except FileExistsError:
     warnings.warn("Font directory already exists")
 
+# Fonts to source from CDN linked by https://notofonts.github.io
+# Includes updates after 2023.
+NEWER_REPO = [
+    "NotoSansArabic",
+]
+
 # Fonts to download in regular, bold, and italic
 REGULAR_BOLD_ITALIC = ["NotoSans"]
 
 # Fonts to download in regular and bold
 REGULAR_BOLD = [
     "NotoSansAdlamUnjoined",
-    "NotoSansArabicUI",
+    "NotoSansArabic",
     "NotoSansArmenian",
     "NotoSansBalinese",
     "NotoSansBamum",
@@ -90,13 +96,18 @@ REGULAR = [
     "NotoSansYi",
 ]
 
-
 # Attempt to download the font from repos in this order
 def findFontUrls(fontName, modifier):
-    return [
-        f"https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/{fontName}/{fontName}-{modifier}.ttf",
-        # currently only sourcing from one repo
-    ]
+    if fontName in NEWER_REPO:
+        subDir = fontName.replace("NotoSans", "").replace("UI", "").lower()
+        return [
+            f"https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io/fonts/{fontName}/hinted/ttf/{fontName}-{modifier}.ttf",
+            f"https://notofonts.github.io/{subDir}/fonts/{fontName}/hinted/ttf/{fontName}-{modifier}.ttf",
+        ]
+    else:
+        return [
+            f"https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/{fontName}/{fontName}-{modifier}.ttf",
+        ]
 
 
 def downloadToFile(urls, destination, dir=FONTDIR):

--- a/scripts/get-fonts.py
+++ b/scripts/get-fonts.py
@@ -19,9 +19,15 @@ except FileExistsError:
 
 # Fonts to source from CDN linked by https://notofonts.github.io
 # Includes updates after 2023.
-NEWER_REPO = [
-    "NotoSansArabic",
-]
+NEWER_NOTO_REPO = []
+
+# Special location of font after Noto stopped updating UI fonts
+REDIRECT_FONTS = {
+    "NotoSansArabic": {
+        "Regular": ["https://github.com/mapmeld/arabic/raw/refs/heads/main/fonts/NotoSansArabicUI/hinted/ttf/NotoSansArabicUI-Regular.ttf"],
+            "Bold": ["https://github.com/mapmeld/arabic/raw/refs/heads/main/fonts/NotoSansArabicUI/hinted/ttf/NotoSansArabicUI-Bold.ttf"]
+    }
+}
 
 # Fonts to download in regular, bold, and italic
 REGULAR_BOLD_ITALIC = ["NotoSans"]
@@ -98,7 +104,11 @@ REGULAR = [
 
 # Attempt to download the font from repos in this order
 def findFontUrls(fontName, modifier):
-    if fontName in NEWER_REPO:
+    if fontName in REDIRECT_FONTS:
+        return REDIRECT_FONTS[fontName][modifier] + [
+            f"https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/{fontName}/{fontName}-{modifier}.ttf",
+        ]
+    elif fontName in NEWER_NOTO_REPO:
         subDir = fontName.replace("NotoSans", "").replace("UI", "").lower()
         return [
             f"https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io/fonts/{fontName}/hinted/ttf/{fontName}-{modifier}.ttf",

--- a/scripts/get-fonts.py
+++ b/scripts/get-fonts.py
@@ -100,8 +100,8 @@ def findFontUrls(fontName, modifier):
     if fontName in NEWER_NOTO_REPO:
         subDir = fontName.replace("NotoSans", "").replace("UI", "").lower()
         return [
-            # f"https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io/fonts/{fontName}/hinted/ttf/{fontName}-{modifier}.ttf",
             f"https://notofonts.github.io/{subDir}/fonts/{fontName}/hinted/ttf/{fontName}-{modifier}.ttf",
+            f"https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io/fonts/{fontName}/hinted/ttf/{fontName}-{modifier}.ttf",
         ]
     else:
         return [

--- a/scripts/get-fonts.py
+++ b/scripts/get-fonts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # This script downloads several Noto fonts from https://github.com/notofonts/noto-fonts
 # That repo was archived in 2023 and is no longer updated.
-# Fonts in the NEWER_REPO list are downloaded from Noto's CDN or individual repos.
+# Fonts in the NEWER_REPO list are downloaded from Noto's GitHub Pages or CDN.
 
 import os
 import requests
@@ -19,15 +19,7 @@ except FileExistsError:
 
 # Fonts to source from CDN linked by https://notofonts.github.io
 # Includes updates after 2023.
-NEWER_NOTO_REPO = []
-
-# Special location of font after Noto stopped updating UI fonts
-REDIRECT_FONTS = {
-    "NotoSansArabic": {
-        "Regular": ["https://github.com/mapmeld/arabic/raw/refs/heads/main/fonts/NotoSansArabicUI/hinted/ttf/NotoSansArabicUI-Regular.ttf"],
-            "Bold": ["https://github.com/mapmeld/arabic/raw/refs/heads/main/fonts/NotoSansArabicUI/hinted/ttf/NotoSansArabicUI-Bold.ttf"]
-    }
-}
+NEWER_NOTO_REPO = ["NotoSansArabicUI"]
 
 # Fonts to download in regular, bold, and italic
 REGULAR_BOLD_ITALIC = ["NotoSans"]
@@ -35,7 +27,7 @@ REGULAR_BOLD_ITALIC = ["NotoSans"]
 # Fonts to download in regular and bold
 REGULAR_BOLD = [
     "NotoSansAdlamUnjoined",
-    "NotoSansArabic",
+    "NotoSansArabicUI",
     "NotoSansArmenian",
     "NotoSansBalinese",
     "NotoSansBamum",
@@ -102,16 +94,13 @@ REGULAR = [
     "NotoSansYi",
 ]
 
+
 # Attempt to download the font from repos in this order
 def findFontUrls(fontName, modifier):
-    if fontName in REDIRECT_FONTS:
-        return REDIRECT_FONTS[fontName][modifier] + [
-            f"https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/{fontName}/{fontName}-{modifier}.ttf",
-        ]
-    elif fontName in NEWER_NOTO_REPO:
+    if fontName in NEWER_NOTO_REPO:
         subDir = fontName.replace("NotoSans", "").replace("UI", "").lower()
         return [
-            f"https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io/fonts/{fontName}/hinted/ttf/{fontName}-{modifier}.ttf",
+            # f"https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io/fonts/{fontName}/hinted/ttf/{fontName}-{modifier}.ttf",
             f"https://notofonts.github.io/{subDir}/fonts/{fontName}/hinted/ttf/{fontName}-{modifier}.ttf",
         ]
     else:

--- a/style/fonts.mss
+++ b/style/fonts.mss
@@ -58,7 +58,7 @@ A regular style.
 */
 @book-fonts:    "Noto Sans Regular",
                 "Noto Sans Adlam Unjoined Regular",
-                "Noto Sans Arabic UI Regular",
+                "Noto Sans Arabic Regular",
                 "Noto Sans Armenian Regular",
                 "Noto Sans Balinese Regular",
                 "Noto Sans Bamum Regular",
@@ -129,7 +129,7 @@ regular text and can be used for emphasis. Fallback is a regular style.
 */
 @bold-fonts:    "Noto Sans Bold",
                 "Noto Sans Adlam Unjoined Bold",
-                "Noto Sans Arabic UI Bold",
+                "Noto Sans Arabic Bold",
                 "Noto Sans Armenian Bold",
                 "Noto Sans Balinese Bold",
                 "Noto Sans Bamum Bold",

--- a/style/fonts.mss
+++ b/style/fonts.mss
@@ -58,7 +58,7 @@ A regular style.
 */
 @book-fonts:    "Noto Sans Regular",
                 "Noto Sans Adlam Unjoined Regular",
-                "Noto Sans Arabic Regular",
+                "Noto Sans Arabic UI Regular",
                 "Noto Sans Armenian Regular",
                 "Noto Sans Balinese Regular",
                 "Noto Sans Bamum Regular",
@@ -129,7 +129,7 @@ regular text and can be used for emphasis. Fallback is a regular style.
 */
 @bold-fonts:    "Noto Sans Bold",
                 "Noto Sans Adlam Unjoined Bold",
-                "Noto Sans Arabic Bold",
+                "Noto Sans Arabic UI Bold",
                 "Noto Sans Armenian Bold",
                 "Noto Sans Balinese Bold",
                 "Noto Sans Bamum Bold",


### PR DESCRIPTION
As discussed in #4893, Google stopped updating our go-to fonts repo https://github.com/notofonts/noto-fonts two years ago. They now distribute multilingual Noto through individual repos, the jsdelivr CDN, and GitHub Pages.

In #5052 we added a Python script to download fonts. For now I suggest a separate list of fonts to download from the new sources (`NEWER_REPO`). As written this would work for most fonts, though there are exceptions (such as the UI fonts and NotoSansKayahLi) which were handled in #4893.

I'd like to update Arabic first here to fix a known issue in Kurdish map labels. I checked with a maintainer in the Noto Arabic repo, and "Arabic UI" is no longer updated; we also want to switch over to the standard font.