### PR TITLE
Merge segmented ways to improve labels and shields

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1832,7 +1832,36 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT
+        -- ST_LineMerge handles the per-connected-component grouping: ways that
+        -- share an endpoint fuse into one linestring; ways that merely cross
+        -- stay as separate parts of the resulting MultiLineString, which ST_Dump
+        -- then unnests so each disjoint piece gets its own label/shield.
+        (WITH raw AS (
+            SELECT
+                osm_id,
+                way,
+                COALESCE(layer, 0) AS layer,
+                COALESCE(
+                  CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') THEN highway END,
+                  CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway END
+                ) AS highway,
+                ref
+              FROM planet_osm_line
+              WHERE way && !bbox!
+              --WHERE way && ST_Expand(!bbox!, 2000)
+                AND (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') OR aeroway IN ('runway', 'taxiway'))
+                AND ref IS NOT NULL
+        ),
+        merged AS (
+            SELECT
+                MIN(osm_id) AS osm_id,
+                (ST_Dump(ST_LineMerge(ST_Collect(way)))).geom AS way,
+                highway,
+                string_to_array(ref, ';') AS refs
+              FROM raw
+              GROUP BY highway, ref, layer
+        )
+        SELECT
             way,
             highway,
             height,
@@ -1846,19 +1875,8 @@ Layer:
                 array_length(refs,1) AS height,
                 (SELECT MAX(char_length(ref)) FROM unnest(refs) AS u(ref)) AS width,
                 array_to_string(refs, E'\n') AS refs
-              FROM (
-                SELECT
-                    osm_id,
-                    way,
-                    COALESCE(
-                      CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') THEN highway END,
-                      CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway END
-                    ) AS highway,
-                    string_to_array(ref, ';') AS refs
-                  FROM planet_osm_line
-                  WHERE (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') OR aeroway IN ('runway', 'taxiway'))
-                    AND ref IS NOT NULL
-              ) AS p) AS q
+              FROM merged
+          ) AS q
           WHERE height <= 4 AND width <= 11
           ORDER BY
             CASE
@@ -1908,12 +1926,67 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |-
+        -- Merged-name layer for issue #951: ways sharing the rendering-relevant
+        -- 5-tuple (highway, tunnel, construction, name, layer) are collected
+        -- and merged via ST_LineMerge so that one label gets placed per logical
+        -- road, not per OSM way. _link is kept in the GROUP BY (as highway_raw)
+        -- to avoid pulling a motorway through its offramp at interchanges; it
+        -- is stripped only at SELECT time for the symbolizer. ST_Dump then
+        -- unnests the MultiLineString that LineMerge returns when the group
+        -- contains disjoint pieces (e.g. two same-named roads that happen to
+        -- cross but share no endpoint), so each piece keeps its own label.
+        --
+        -- The one-way arrows live in a separate, unmerged layer
+        -- (roads-direction-arrows) because ST_LineMerge does not preserve
+        -- linestring orientation.
+        (WITH raw AS (
+            SELECT
+                way,
+                osm_id,
+                z_order,
+                COALESCE(layer, 0) AS layer,
+                highway AS highway_raw,
+                CASE WHEN substr(highway, length(highway)-4, 5) = '_link' THEN substr(highway, 0, length(highway)-4) ELSE highway END AS highway,
+                CASE WHEN (tunnel IN ('yes', 'building_passage', 'avalanche_protector') OR covered = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,
+                construction,
+                name
+              FROM planet_osm_line
+              WHERE way && !bbox!
+              --WHERE way && ST_Expand(!bbox!, 2000)
+                AND highway IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary',
+                                'tertiary_link', 'residential', 'unclassified', 'road', 'service', 'pedestrian', 'raceway', 'living_street', 'construction', 'bus_guideway')
+                AND name IS NOT NULL
+        )
+        SELECT
+            (ST_Dump(ST_LineMerge(ST_Collect(way)))).geom AS way,
+            highway,
+            tunnel,
+            construction,
+            name
+          FROM raw
+          GROUP BY highway_raw, highway, tunnel, construction, name, layer
+          ORDER BY
+            MAX(z_order) DESC, -- put important roads first
+            layer, -- put top layered roads first
+            length(name) DESC, -- Try to fit big labels in first
+            name DESC, -- Force a consistent ordering between differently named streets
+            MIN(osm_id) DESC -- Force an ordering for streets of the same name, e.g. dualized roads
+        ) AS roads_text_name
+    properties:
+      cache-features: true
+      minzoom: 13
+  - id: roads-direction-arrows
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        -- One-way arrows must be rendered per original OSM way because
+        -- ST_LineMerge does not preserve direction. Kept separate from
+        -- roads-text-name so the name labels can use merged geometry.
         (SELECT
             way,
-            CASE WHEN substr(highway, length(highway)-4, 5) = '_link' THEN substr(highway, 0, length(highway)-4) ELSE highway END,
-            CASE WHEN (tunnel IN ('yes', 'building_passage', 'avalanche_protector') OR covered = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,
-            construction,
-            name,
+            CASE WHEN substr(highway, length(highway)-4, 5) = '_link' THEN substr(highway, 0, length(highway)-4) ELSE highway END AS highway,
             CASE
               WHEN oneway IN ('yes', '-1') THEN oneway
               WHEN junction IN ('roundabout') AND (oneway IS NULL OR NOT oneway IN ('no', 'reversible')) THEN 'yes'
@@ -1921,19 +1994,15 @@ Layer:
           FROM planet_osm_line l
           WHERE highway IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary',
                             'tertiary_link', 'residential', 'unclassified', 'road', 'service', 'pedestrian', 'raceway', 'living_street', 'construction', 'bus_guideway')
-            AND (name IS NOT NULL
-              OR oneway IN ('yes', '-1')
-              OR junction IN ('roundabout'))
+            AND (oneway IN ('yes', '-1') OR junction IN ('roundabout'))
           ORDER BY
             z_order DESC, -- put important roads first
             COALESCE(layer, 0), -- put top layered roads first
-            length(name) DESC, -- Try to fit big labels in first
-            name DESC, -- Force a consistent ordering between differently named streets
             l.osm_id DESC -- Force an ordering for streets of the same name, e.g. dualized roads
-        ) AS roads_text_name
+        ) AS roads_direction_arrows
     properties:
       cache-features: true
-      minzoom: 13
+      minzoom: 16
   - id: paths-text-name
     geometry: linestring
     <<: *extents
@@ -1999,7 +2068,31 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT
+        -- Merged shield layer for issue #951; see roads-text-ref for the
+        -- same pattern.
+        (WITH raw AS (
+            SELECT
+                osm_id,
+                way,
+                COALESCE(layer, 0) AS layer,
+                CASE WHEN highway IN ('unclassified', 'residential', 'track') THEN highway END AS highway,
+                ref
+              FROM planet_osm_line
+              WHERE way && !bbox!
+              --WHERE way && ST_Expand(!bbox!, 2000)
+                AND highway IN ('unclassified', 'residential', 'track')
+                AND ref IS NOT NULL
+        ),
+        merged AS (
+            SELECT
+                MIN(osm_id) AS osm_id,
+                (ST_Dump(ST_LineMerge(ST_Collect(way)))).geom AS way,
+                highway,
+                string_to_array(ref, ';') AS refs
+              FROM raw
+              GROUP BY highway, ref, layer
+        )
+        SELECT
             way,
             highway,
             height,
@@ -2013,16 +2106,8 @@ Layer:
                 array_length(refs,1) AS height,
                 (SELECT MAX(char_length(ref)) FROM unnest(refs) AS u(ref)) AS width,
                 array_to_string(refs, E'\n') AS refs
-              FROM (
-                SELECT
-                    osm_id,
-                    way,
-                    CASE WHEN highway IN ('unclassified', 'residential', 'track') THEN highway END AS highway,
-                    string_to_array(ref, ';') AS refs
-                  FROM planet_osm_line
-                  WHERE highway IN ('unclassified', 'residential', 'track')
-                    AND ref IS NOT NULL
-              ) AS p) AS q
+              FROM merged
+          ) AS q
           WHERE height <= 4 AND width <= 11
           ORDER BY
             CASE

--- a/project.mml
+++ b/project.mml
@@ -1848,7 +1848,6 @@ Layer:
                 ref
               FROM planet_osm_line
               WHERE way && !bbox!
-              --WHERE way && ST_Expand(!bbox!, 2000)
                 AND (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') OR aeroway IN ('runway', 'taxiway'))
                 AND ref IS NOT NULL
         ),
@@ -1952,7 +1951,6 @@ Layer:
                 name
               FROM planet_osm_line
               WHERE way && !bbox!
-              --WHERE way && ST_Expand(!bbox!, 2000)
                 AND highway IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary',
                                 'tertiary_link', 'residential', 'unclassified', 'road', 'service', 'pedestrian', 'raceway', 'living_street', 'construction', 'bus_guideway')
                 AND name IS NOT NULL
@@ -2079,7 +2077,6 @@ Layer:
                 ref
               FROM planet_osm_line
               WHERE way && !bbox!
-              --WHERE way && ST_Expand(!bbox!, 2000)
                 AND highway IN ('unclassified', 'residential', 'track')
                 AND ref IS NOT NULL
         ),

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -3438,6 +3438,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [man_made = 'bridge'] {
     [zoom >= 12][way_pixels > 125][way_pixels <= 768000] {
       text-name: "[name]";
+      text-avoid-edges: true;
       text-size: 10;
       text-wrap-width: 30; // 3 em
       text-line-spacing: -1.2; // -0.15 em
@@ -3713,6 +3714,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     shield-margin: @shield-margin;
     shield-face-name: @shield-font;
     shield-clip: @shield-clip;
+    shield-avoid-edges: true;
 
     [highway = 'motorway'] {
       shield-fill: @motorway-shield;
@@ -3762,6 +3764,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       shield-margin: @shield-margin;
       shield-face-name: @shield-font;
       shield-clip: @shield-clip;
+      shield-avoid-edges: true;
 
       [highway = 'motorway'] {
         shield-fill: @motorway-shield;
@@ -3824,6 +3827,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'taxiway'] {
     [zoom >= 15] {
       text-name: "[refs]";
+      text-avoid-edges: true;
       text-size: 10;
       text-fill: #333;
       text-spacing: 750;
@@ -3838,10 +3842,12 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 }
 
 #roads-text-ref-minor {
+  // Issue #951: see roads-text-name comment above
   [highway = 'unclassified'],
   [highway = 'residential'] {
     [zoom >= 15] {
       text-name: "[refs]";
+      text-avoid-edges: true;
       text-size: 8;
 
       [zoom >= 16] {
@@ -3865,6 +3871,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'track'] {
     [zoom >= 15] {
       text-name: "[refs]";
+      text-avoid-edges: true;
       text-size: 8;
       text-dy: 5;
 
@@ -3892,6 +3899,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 }
 
 #roads-text-name {
+  // Issue #951: this layer ships pre-merged geometries, so text-avoid-edges
+  // must be on every text symbolizer below to suppress duplicate labels at
+  // metatile seams.
   [highway = 'motorway'],
   [highway = 'trunk'],
   [highway = 'primary'],
@@ -3900,6 +3910,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'construction'][construction = 'primary'] {
     [zoom >= 13] {
       text-name: "[name]";
+      text-avoid-edges: true;
       text-size: 8;
       text-fill: black;
       text-spacing: 300;
@@ -3931,6 +3942,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'construction'][construction = 'secondary'] {
     [zoom >= 13] {
       text-name: "[name]";
+      text-avoid-edges: true;
       text-size: 8;
       text-fill: black;
       text-spacing: 300;
@@ -3958,6 +3970,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'construction'][construction = 'tertiary'] {
     [zoom >= 14] {
       text-name: "[name]";
+      text-avoid-edges: true;
       text-size: 9;
       text-fill: black;
       text-spacing: 300;
@@ -3977,6 +3990,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   }
   [highway = 'construction'][construction = null][zoom >= 16] {
     text-name: "[name]";
+    text-avoid-edges: true;
     text-size: 9;
     text-fill: black;
     text-spacing: 300;
@@ -4005,6 +4019,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'construction'][construction = 'road'] {
     [zoom >= 15] {
       text-name: "[name]";
+      text-avoid-edges: true;
       text-size: 8;
       text-fill: black;
       text-spacing: 300;
@@ -4035,6 +4050,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'construction'][construction = 'service'][zoom >= 17] {
     [zoom >= 16] {
       text-name: "[name]";
+      text-avoid-edges: true;
       text-size: 9;
       text-fill: black;
       text-spacing: 300;
@@ -4057,6 +4073,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'construction'][construction = 'pedestrian'][zoom >= 16] {
     [zoom >= 15] {
       text-name: "[name]";
+      text-avoid-edges: true;
       text-size: 8;
       text-fill: black;
       text-spacing: 300;

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -4153,7 +4153,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   }
 }
 
-#roads-text-name::directions,
+// Issue #951: directions for roads live in a dedicated, unmerged layer
+// (roads-direction-arrows) because ST_LineMerge does not preserve linestring
+// orientation. Paths still attach as a sub-symbolizer on paths-text-name.
+#roads-direction-arrows,
 #paths-text-name::directions {
   [zoom >= 16] {
     // intentionally omitting highway_platform, highway_construction


### PR DESCRIPTION
Fixes #951

When a road is split across many ways that all share `name`, `ref`, and highway tags (such as at admin boundaries, when maxspeed changes, etc), each of these individual ways are labeled independently. This results in too many, or too few, labels and shields on what is really one logical road. As described in #951.

Here's a representative test case that I added to my Postgres. The top road is 1 way. The bottom road has 5 nodes connected by 4 ways.

Before this PR, they rendered quite differently:
<img width="400" alt="Screen Shot 2026-05-18 at 9 54 26 PM" src="https://github.com/user-attachments/assets/207094d8-873b-4f6f-b004-f215b33eff2e" />


After this PR, they render (almost) exactly the same (asterisk see later):
<img width="400" alt="Screen Shot 2026-05-18 at 9 53 02 PM" src="https://github.com/user-attachments/assets/a8f8c1e2-68a9-4c57-9f71-004607f86437" />


Changes proposed in this pull request:
- **Join up linestrings that have identical references and highway types**
- Three datasources will now GROUP BY the set of columns that control their rendering: `roads-text-ref`, `roads-text-name`, `roads-text-ref-minor`. In each case, we collect the ways in each group, and call this magical Postgres incantation: `(ST_Dump(ST_LineMerge(ST_Collect(way)))).geom`. First, `ST_LineMerge` looks at the collection of ways, and fuses anything that shares an exact endpoint. Importantly, if a way just crosses another way (while sharing rendering information), that is insufficient - they have to actually touch _at their endpoint_, which practically means they share an OSM node as an endpoint. There is also a `_link` check that is intentionally preserved so that the linestring building is not "distracted" by junctions and offramps. Even though such an offramp might be rendered no different to the highway, we put all offramps in a separate partition. Otherwise the linestring would be interrupted at every offramp because `ST_LineMerge` stops the linestring whenever it reaches an intersection of 3 or more lines. `ST_LineMerge` is run independently in each group/partition, so most of the time it will return a single coherent linestring. But some of the time it will fail to merge everything. Not a problem, maybe there are two roads with the exact same name without actually touching. In that case, `ST_Dump` brings us back down to those individual linestrings again, it's the opposite of `ST_Collect`.
- Directional arrows were wrong in my first version, this is because `ST_LineMerge` completely forgets about the orientation of each line. I replaced `#roads-text-name::directions` with a new path that is not going to do any merging, `#roads-direction-arrows`. In other words, we had to keep arrows rendered exactly as they were, but to do that they had to be separated from `roads-text-name`.
- I did not change road casing/fill. Technically, it changes a few pixels a teensy bit if you apply the line merging there, because of the rounded corners at the end of each way, but this is overkill in my opinion.

[The PostGIS documentation](https://postgis.net/docs/ST_LineMerge.html) for `ST_LineMerge` has these images that make it clear, blue is the "before" and red is the "after":
<img width="200" height="200" alt="st_linemerge01" src="https://github.com/user-attachments/assets/b5508d34-a202-4327-83fd-b2cf403a1fc9" />
<img width="200" height="200" alt="st_linemerge02" src="https://github.com/user-attachments/assets/0741c2b2-e98d-462d-a876-df643ae61215" />

This demonstrates how 1. direction is forgotten 2. when three lines come together, `ST_LineMerge` keeps them separate (now you can imagine why offramps were a problem). You may wonder: why not turn on `directed => true` in our call to `ST_LineMerge`? Because the vast majority of roads are not actually one-way roads, and that option would affect **all** roads in the tile, meaning a change in the node order of the way would cause a break in the labeling for all roads.

<details>
<summary>
Asterisk from earlier
</summary>

In order to get the two roads to render **identically**, I had to expand some bboxes, specifically making the labels and shields use `ST_Expand(!bbox!, 2000)`. You can see where I removed that code here https://github.com/leijurv/openstreetmap-carto/commit/aba93ac770c6b8bb4c84a98e0f12abd4976b4a64 So technically that earlier screenshot is not from this exact code with the regular bbox. This is what it looks like for real, as you can see the shields are close but I could not get them to be identical no matter how hard I tried unless I cheated a little bit and selected a larger area due to tile boundary problems. Forgive me, I wanted the impressive screenshot with a truly identical result 🙏 

<img width="400" alt="Screen Shot 2026-05-18 at 9 55 27 PM" src="https://github.com/user-attachments/assets/db28b5ca-aea9-45d4-a846-636f73dc0ead" />
</details>

Test rendering. The main change is way more labels are shown. The shields are a bit different but pretty similar.

`#13/40.7408/-73.9584`
<img width="3336" height="1910" alt="nyc png" src="https://github.com/user-attachments/assets/102178a6-70cc-42b3-90df-e1e0824bbfb7" />

`#13/52.2321/20.9672`
<img width="3336" height="1910" alt="warsaw png" src="https://github.com/user-attachments/assets/7c3f9f59-691f-494b-97bf-6e80fb2837a5" />

`#13/37.7610/-122.4440`
<img width="3336" height="1910" alt="sf png" src="https://github.com/user-attachments/assets/25ec412d-b3fa-44d5-b334-2ad622c7a750" />

