### PR TITLE
Thinner dams (1px stroke Z13-15)

### DIFF
--- a/style/water-features.mss
+++ b/style/water-features.mss
@@ -8,12 +8,11 @@
 #water-barriers-point, #water-barriers-line, #water-barriers-poly {
   [waterway = 'dam'] {
     #water-barriers-poly[zoom >= 13] {
-      line-width: 1;
+      line-width: 2;
       line-color: @dam-line;
       line-join: round;
       line-cap: round;
       polygon-fill: @dam;
-      [zoom >= 16] { line-width: 2; }
     }
     #water-barriers-line[zoom >= 13] {
       line-width: 1;

--- a/style/water-features.mss
+++ b/style/water-features.mss
@@ -8,17 +8,19 @@
 #water-barriers-point, #water-barriers-line, #water-barriers-poly {
   [waterway = 'dam'] {
     #water-barriers-poly[zoom >= 13] {
-      line-width: 2;
+      line-width: 1;
       line-color: @dam-line;
       line-join: round;
       line-cap: round;
       polygon-fill: @dam;
+      [zoom >= 16] { line-width: 2; }
     }
     #water-barriers-line[zoom >= 13] {
-      line-width: 2;
+      line-width: 1;
       line-color: @dam-line;
       line-join: round;
       line-cap: round;
+      [zoom >= 16] { line-width: 2; }
     }
     #water-barriers-point[zoom >= 17] {
       marker-fill: @dam;

--- a/style/water-features.mss
+++ b/style/water-features.mss
@@ -1,6 +1,7 @@
 @breakwater-color: #aaa; /* Also for groyne */
 @dam: #adadad;
 @dam-line: #444444;
+@dam-line-low-zoom: #787878;
 @weir-line: #aaa;
 @lock-gate: #aaa;
 @lock-gate-line: #aaa;
@@ -8,18 +9,33 @@
 #water-barriers-point, #water-barriers-line, #water-barriers-poly {
   [waterway = 'dam'] {
     #water-barriers-poly[zoom >= 13] {
-      line-width: 2;
-      line-color: @dam-line;
+      line-width: 1;
+      line-color: @dam-line-low-zoom;
       line-join: round;
       line-cap: round;
+      [zoom >= 15] {
+        line-width: 2;
+        line-color: @dam-line;
+      }
       polygon-fill: @dam;
     }
-    #water-barriers-line[zoom >= 13] {
-      line-width: 1;
+    #water-barriers-line[zoom >= 15]::casing {
+      line-width: 3;
       line-color: @dam-line;
       line-join: round;
       line-cap: round;
-      [zoom >= 16] { line-width: 2; }
+      [zoom >= 16] { line-width: 4; }
+    }
+    #water-barriers-line[zoom >= 13] {
+      line-width: 2;
+      line-color: @dam-line-low-zoom;
+      line-join: round;
+      line-cap: round;
+      [zoom >= 15] {
+        line-width: 1;
+        line-color: @dam;
+        [zoom >= 16] { line-width: 2; }
+      }
     }
     #water-barriers-point[zoom >= 17] {
       marker-fill: @dam;

--- a/style/water-features.mss
+++ b/style/water-features.mss
@@ -2,6 +2,7 @@
 @dam: #adadad;
 @dam-line: #444444;
 @dam-line-low-zoom: #787878;
+@dam-line-mid-zoom: #5e5e5e;
 @weir-line: #aaa;
 @lock-gate: #aaa;
 @lock-gate-line: #aaa;
@@ -9,32 +10,36 @@
 #water-barriers-point, #water-barriers-line, #water-barriers-poly {
   [waterway = 'dam'] {
     #water-barriers-poly[zoom >= 13] {
-      line-width: 1;
-      line-color: @dam-line-low-zoom;
-      line-join: round;
-      line-cap: round;
-      [zoom >= 15] {
-        line-width: 2;
-        line-color: @dam-line;
-      }
       polygon-fill: @dam;
+      [zoom >= 14] {
+        line-width: 1;
+        line-color: @dam-line-low-zoom;
+        line-join: round;
+        [zoom >= 15] {
+          line-width: 1.5;
+          [zoom >= 16] { line-width: 2; }
+        }
+      }
     }
-    #water-barriers-line[zoom >= 15]::casing {
-      line-width: 3;
-      line-color: @dam-line;
-      line-join: round;
-      line-cap: round;
-      [zoom >= 16] { line-width: 4; }
-    }
-    #water-barriers-line[zoom >= 13] {
-      line-width: 2;
+    #water-barriers-line[zoom >= 13][zoom < 15] {
+      line-width: 1.6;
       line-color: @dam-line-low-zoom;
       line-join: round;
       line-cap: round;
-      [zoom >= 15] {
-        line-width: 1;
-        line-color: @dam;
-        [zoom >= 16] { line-width: 2; }
+      [zoom >= 14] { line-width: 2; }
+    }
+    /* Flat line ends so the casing shows only on the long sides,
+       distinguishing linear dams from polygon dams */
+    #water-barriers-line[zoom >= 15] {
+      casing/line-width: 2.6;
+      casing/line-color: @dam-line-mid-zoom;
+      casing/line-join: round;
+      line-width: 1;
+      line-color: @dam;
+      line-join: round;
+      [zoom >= 16] {
+        casing/line-width: 4;
+        line-width: 2;
       }
     }
     #water-barriers-point[zoom >= 17] {

--- a/style/water-features.mss
+++ b/style/water-features.mss
@@ -1,8 +1,7 @@
 @breakwater-color: #aaa; /* Also for groyne */
 @dam: #adadad;
-@dam-line: #444444;
+@dam-line: #5e5e5e;
 @dam-line-low-zoom: #787878;
-@dam-line-mid-zoom: #5e5e5e;
 @weir-line: #aaa;
 @lock-gate: #aaa;
 @lock-gate-line: #aaa;
@@ -15,10 +14,7 @@
         line-width: 1;
         line-color: @dam-line-low-zoom;
         line-join: round;
-        [zoom >= 15] {
-          line-width: 1.5;
-          [zoom >= 16] { line-width: 2; }
-        }
+        [zoom >= 15] { line-color: @dam-line; }
       }
     }
     #water-barriers-line[zoom >= 13][zoom < 15] {
@@ -32,7 +28,7 @@
        distinguishing linear dams from polygon dams */
     #water-barriers-line[zoom >= 15] {
       casing/line-width: 2.6;
-      casing/line-color: @dam-line-mid-zoom;
+      casing/line-color: @dam-line;
       casing/line-join: round;
       line-width: 1;
       line-color: @dam;


### PR DESCRIPTION
Fixes #4231 

Changes proposed in this pull request:
- At Z13 Z14 Z15, change the line-width of dams from 2px to 1px **only** for line dams, leaving polygon unchanged.

Polygon dams have a rendered area that looks okay at 2px. But line dams are too dark and too heavy at 2px to my eyes.

There are seven images per location, so I collapsed them:
<details>
<summary><b>The originally reported area in #4231 (click to expand)</b></summary>

`#13/40.1609/-122.4687`

<b>Z13 before</b>
<img width="1728" height="955" alt="z13 before" src="https://github.com/user-attachments/assets/45355585-86d8-4212-a5ee-a85a70b5ecad" />

<b>Z13 after</b>
<img width="1728" height="955" alt="z13 after" src="https://github.com/user-attachments/assets/bc88d52d-2a5a-4393-9926-55baca2b0595" />


<b>Z14 before</b>
<img width="1728" height="955" alt="z14 before" src="https://github.com/user-attachments/assets/da810d0f-f08e-4d50-a0dc-e9ea9c320bb5" />


<b>Z14 after</b>
<img width="1728" height="955" alt="z14 after" src="https://github.com/user-attachments/assets/feb9d5fb-d4c9-418b-bf14-46c7966863ca" />


<b>Z15 before</b>
<img width="1728" height="955" alt="z15 before" src="https://github.com/user-attachments/assets/6d4babdb-696b-40b4-8761-62f7a7f5aad5" />


<b>Z15 after</b>
<img width="1728" height="955" alt="z15 after" src="https://github.com/user-attachments/assets/1a975210-f173-4923-9492-c5ada0f95062" />


<b>Z16 unchanged</b>
<img width="1728" height="955" alt="z16" src="https://github.com/user-attachments/assets/bdbb4702-5bff-4f09-b7b1-095e7a2cad93" />


</details>

<details>
<summary><b>Example of a polygon dam, mostly unchanged, but it has one section of line that is changed (click to expand)</b></summary>

`#13/37.94748/-119.78583`

<b>Z13 before</b>
<img width="57" height="45" alt="z13 before" src="https://github.com/user-attachments/assets/2dee5a73-9039-4b85-b63c-3454adbae7c9" />


<b>Z13 after</b>
<img width="57" height="45" alt="z13 after" src="https://github.com/user-attachments/assets/021b734f-ef71-469d-acf5-2a35be1a417f" />


<b>Z14 before</b>
<img width="113" height="90" alt="z14 before" src="https://github.com/user-attachments/assets/6cfc5cea-5391-4d4c-ae86-f16d81b5f5d3" />


<b>Z14 after</b>
<img width="113" height="90" alt="z14 after" src="https://github.com/user-attachments/assets/ba45e3f8-a8e7-4977-9966-eb69c85c057d" />


<b>Z15 before</b>
<img width="227" height="180" alt="z15 before" src="https://github.com/user-attachments/assets/400d194f-1e23-47d9-a6c4-5ac0b82d7914" />


<b>Z15 after</b>
<img width="227" height="180" alt="z15 after" src="https://github.com/user-attachments/assets/600c8ca4-0901-4dc0-b474-c6ccab890ff7" />
 ^ See in this one how the stroke width is more pleasingly proportioned


<b>Z16 unchanged</b>
<img width="453" height="359" alt="z16" src="https://github.com/user-attachments/assets/1367cf5c-e476-4ae5-95a2-c3b997884d3c" />


</details>


Questions:
- Maybe Z15 should be 1.5px?
- Should it depend on the total size of the dam? Like the perceptual length of the line, in pixels. I would lean towards no just because it would be an unclear feature that could cause confusion for mappers and for users.
