### PR TITLE
Charging station primary label

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1580,6 +1580,8 @@ Layer:
               CASE
                 WHEN amenity = 'parcel_locker'
                 THEN CONCAT_WS(E'\n', COALESCE(tags->'brand', tags->'operator', name), ref)
+                WHEN amenity = 'charging_station' -- brand, with capacity in parentheses; no label without a brand
+                THEN tags->'brand' || COALESCE(CASE WHEN tags->'capacity' ~ '^\d+$' THEN CONCAT(' (', tags->'capacity', ')') END, '')
                 ELSE
                 CONCAT(
                   name,

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2437,6 +2437,7 @@
 
   [feature = 'highway_bus_stop'],
   [feature = 'amenity_fuel'],
+  [feature = 'amenity_charging_station'],
   [feature = 'amenity_bus_station'] {
     [zoom >= 17] {
       text-name: "[name]";


### PR DESCRIPTION
Fixes part of #4450 

Changes proposed in this pull request:
- Adds `[Brand] ([Capacity])` (Such as `Tesla (8)`) to the primary label of charging stations

Logic notes:
- If a station has a `capacity`, but no `brand` tag, no label is rendered (retaining current rendering).

LLM Disclaimer:
- I used Claude Opus 4.8 to identify the correct file and line, edits were made by hand after verification.