### PR TITLE
Shorten multi-component flat and housenumber lists

### DIFF
--- a/functions.sql
+++ b/functions.sql
@@ -103,3 +103,22 @@ SELECT
 		ELSE CAST(ROUND(LOG(2, 559082264.028 / scale_denominator)) AS integer)
 	END
 $$;
+
+-- Returns the original semicolon-separated list if it contains at most two items;
+-- otherwise returns the first and last items separated by a midline ellipsis (U+22EF).
+CREATE OR REPLACE FUNCTION carto_shorten_list(listtext text)
+  RETURNS text
+  LANGUAGE SQL
+  IMMUTABLE PARALLEL SAFE 
+AS $$
+SELECT
+  CASE
+    WHEN array_length(parts,1) > 2
+      THEN parts[1] || chr(x'2026'::int) || parts[array_length(parts,1)]
+    ELSE listtext
+  END
+  FROM (
+    SELECT string_to_array(listtext, ';') AS parts
+  ) _;
+$$;
+

--- a/functions.sql
+++ b/functions.sql
@@ -104,61 +104,53 @@ SELECT
 	END
 $$;
 
--- Tests whether substring a or b is present in argument, returning a or b
--- as appropriate. Returns NULL if neither OR both present
-CREATE OR REPLACE FUNCTION carto_test_alternative_substrings(arg text, a text, b text)
-  RETURNS text
-  LANGUAGE SQL
-  IMMUTABLE PARALLEL SAFE 
-AS $$
-SELECT
-  CASE
-    WHEN position(a in arg) > 0
-      THEN CASE WHEN position(b in arg) = 0 THEN a END
-    WHEN position(b in arg) > 0
-      THEN b
-  END
-$$;
-
 /* Try to shorten a list of entries if the length is more than maxlength characters
-   The list is partitioned using the given separator (if a single character) and
-   shortened if it contains more then two items, by returning the first and last
-   itens separated by a ellipsis (U+2026).
-   If the separator argument contains two alternative characters, both are tested, and
-   the shortening attempted if one, but not both, separators are found. */
+   The list is partitioned using the given separator and shortened if it contains
+   more then two items, by returning the first and last items separated by a ellipsis (U+2026).
+   If the separator argument multiple characters, the shortening attempted if one, but not more,
+   separator types is found. */
+
 CREATE OR REPLACE FUNCTION carto_shorten_list(
-  listtext text, 
-  separator text,
-  maxlength int default 10
+    listtext text,
+    separators text,
+    maxlength integer DEFAULT 10
   )
   RETURNS text
-  LANGUAGE SQL
-  IMMUTABLE PARALLEL SAFE 
+  LANGUAGE plpgsql
+  IMMUTABLE PARALLEL SAFE
 AS $$
-SELECT
-  CASE
-    WHEN (separator IS NULL) OR (length(listtext) <= maxlength) -- also followed if input is NULL
-      THEN listtext
+DECLARE
+  found_sep   text;
+  sep         text;
+  parts       text[];
+BEGIN
+  IF listtext IS NULL
+    OR separators IS NULL
+    OR length(listtext) <= maxlength THEN
+      RETURN listtext;
+  END IF;
 
-    WHEN length(separator) = 1
-    THEN (
-      SELECT CASE
-        WHEN array_length(parts,1) > 2
-        THEN parts[1] || chr(x'2026'::int) || parts[array_length(parts,1)]
-        ELSE listtext
-      END
-      FROM (
-        SELECT string_to_array(listtext, separator) AS parts
-      ) _
-    )
+  -- Find separator types present in the text
+  FOR sep IN
+    SELECT substr(separators, i, 1)
+      FROM generate_series(1, length(separators)) AS g(i)
+  LOOP
+    IF position(sep IN listtext) > 0 THEN
+      IF found_sep IS NOT NULL THEN
+        -- Multiple separator types found: do not shorten
+        RETURN listtext;
+      END IF;
+      found_sep := sep;
+    END IF;
+  END LOOP;
 
-    WHEN length(separator) = 2
-    THEN
-      carto_shorten_list(
-        listtext,
-        carto_test_alternative_substrings(listtext, left(separator, 1), right(separator, 1)),
-        maxlength
-      )
-  END -- NULL returned if separator argument is invalid
+  IF found_sep IS NOT NULL THEN
+    parts := string_to_array(listtext, found_sep);
+    IF array_length(parts, 1) > 2 THEN
+      RETURN parts[1] || chr(x'2026'::int) || parts[array_length(parts, 1)];
+    END IF;
+  END IF;
+
+  RETURN listtext;
+END;
 $$;
-

--- a/functions.sql
+++ b/functions.sql
@@ -131,10 +131,8 @@ BEGIN
   END IF;
 
   -- Find separator types present in the text
-  FOR sep IN
-    SELECT substr(separators, i, 1)
-      FROM generate_series(1, length(separators)) AS g(i)
-  LOOP
+  FOR i IN 1 .. length(separators) LOOP
+    sep := substr(separators, i, 1);
     IF position(sep IN listtext) > 0 THEN
       IF found_sep IS NOT NULL THEN
         -- Multiple separator types found: do not shorten

--- a/functions.sql
+++ b/functions.sql
@@ -104,21 +104,61 @@ SELECT
 	END
 $$;
 
--- Returns the original semicolon-separated list if it contains at most two items;
--- otherwise returns the first and last items separated by a midline ellipsis (U+22EF).
-CREATE OR REPLACE FUNCTION carto_shorten_list(listtext text)
+-- Tests whether substring a or b is present in argument, returning a or b
+-- as appropriate. Returns NULL if neither OR both present
+CREATE OR REPLACE FUNCTION carto_test_alternative_substrings(arg text, a text, b text)
   RETURNS text
   LANGUAGE SQL
   IMMUTABLE PARALLEL SAFE 
 AS $$
 SELECT
   CASE
-    WHEN array_length(parts,1) > 2
-      THEN parts[1] || chr(x'2026'::int) || parts[array_length(parts,1)]
-    ELSE listtext
+    WHEN position(a in arg) > 0
+      THEN CASE WHEN position(b in arg) = 0 THEN a END
+    WHEN position(b in arg) > 0
+      THEN b
   END
-  FROM (
-    SELECT string_to_array(listtext, ';') AS parts
-  ) _;
+$$;
+
+/* Try to shorten a list of entries if the length is more than maxlength characters
+   The list is partitioned using the given separator (if a single character) and
+   shortened if it contains more then two items, by returning the first and last
+   itens separated by a ellipsis (U+2026).
+   If the separator argument contains two alternative characters, both are tested, and
+   the shortening attempted if one, but not both, separators are found. */
+CREATE OR REPLACE FUNCTION carto_shorten_list(
+  listtext text, 
+  separator text,
+  maxlength int default 10
+  )
+  RETURNS text
+  LANGUAGE SQL
+  IMMUTABLE PARALLEL SAFE 
+AS $$
+SELECT
+  CASE
+    WHEN (separator IS NULL) OR (length(listtext) <= maxlength) -- also followed if input is NULL
+      THEN listtext
+
+    WHEN length(separator) = 1
+    THEN (
+      SELECT CASE
+        WHEN array_length(parts,1) > 2
+        THEN parts[1] || chr(x'2026'::int) || parts[array_length(parts,1)]
+        ELSE listtext
+      END
+      FROM (
+        SELECT string_to_array(listtext, separator) AS parts
+      ) _
+    )
+
+    WHEN length(separator) = 2
+    THEN
+      carto_shorten_list(
+        listtext,
+        carto_test_alternative_substrings(listtext, left(separator, 1), right(separator, 1)),
+        maxlength
+      )
+  END -- NULL returned if separator argument is invalid
 $$;
 

--- a/project.mml
+++ b/project.mml
@@ -2209,10 +2209,10 @@ Layer:
       table: |-
         (SELECT
             ST_PointOnSurface(way) AS way,
-            "addr:housenumber" AS addr_housenumber,
+            carto_shorten_list("addr:housenumber") AS addr_housenumber,
             "addr:housename" AS addr_housename,
             tags->'addr:unit' AS addr_unit,
-            tags->'addr:flats' AS addr_flats,
+            carto_shorten_list(tags->'addr:flats') AS addr_flats,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
           WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
@@ -2222,10 +2222,10 @@ Layer:
         UNION ALL
         SELECT
             way,
-            "addr:housenumber" AS addr_housenumber,
+            carto_shorten_list("addr:housenumber") AS addr_housenumber,
             "addr:housename" AS addr_housename,
             tags->'addr:unit' AS addr_unit,
-            tags->'addr:flats' AS addr_flats,
+            carto_shorten_list(tags->'addr:flats') AS addr_flats,
             NULL::float AS way_pixels
           FROM planet_osm_point
           WHERE way && !bbox!

--- a/project.mml
+++ b/project.mml
@@ -2216,7 +2216,7 @@ Layer:
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
           WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
-            AND (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL) OR ((tags->'addr:flats') IS NOT NULL))
+            AND (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR tags ? 'addr:unit' OR tags ? 'addr:flats')
             AND building IS NOT NULL
             AND way_area < 4000000*POW(!scale_denominator!*0.001*0.28,2)
         UNION ALL
@@ -2229,7 +2229,7 @@ Layer:
             NULL::float AS way_pixels
           FROM planet_osm_point
           WHERE way && !bbox!
-            AND (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL) OR ((tags->'addr:flats') IS NOT NULL))
+            AND (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR tags ? 'addr:unit' OR tags ? 'addr:flats')
           ORDER BY way_pixels DESC NULLS LAST
         ) AS addresses
     properties:

--- a/project.mml
+++ b/project.mml
@@ -2209,10 +2209,10 @@ Layer:
       table: |-
         (SELECT
             ST_PointOnSurface(way) AS way,
-            carto_shorten_list("addr:housenumber") AS addr_housenumber,
+            carto_shorten_list("addr:housenumber", ',;') AS addr_housenumber,
             "addr:housename" AS addr_housename,
             tags->'addr:unit' AS addr_unit,
-            carto_shorten_list(tags->'addr:flats') AS addr_flats,
+            carto_shorten_list(tags->'addr:flats', ';') AS addr_flats, 
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
           WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
@@ -2222,10 +2222,10 @@ Layer:
         UNION ALL
         SELECT
             way,
-            carto_shorten_list("addr:housenumber") AS addr_housenumber,
+            carto_shorten_list("addr:housenumber", ',;') AS addr_housenumber,
             "addr:housename" AS addr_housename,
             tags->'addr:unit' AS addr_unit,
-            carto_shorten_list(tags->'addr:flats') AS addr_flats,
+            carto_shorten_list(tags->'addr:flats', ';') AS addr_flats,
             NULL::float AS way_pixels
           FROM planet_osm_point
           WHERE way && !bbox!


### PR DESCRIPTION
Fixes #4155 
Partially addresses #4160 

Changes proposed in this pull request:
- Adds `carto_shorten_list` SQL function which compresses semicolon-separated lists if >2 entries
- Applies function to `addr:housename` and `addr:flats`, but not `addr:unit`, which is not expected to contain multiple entries

Demonstration on artificial example at Z18:

Before

<img width="494" height="416" alt="image" src="https://github.com/user-attachments/assets/62b37215-6948-493a-a2df-a834bbe68aa3" />

After

<img width="507" height="424" alt="image" src="https://github.com/user-attachments/assets/864ab04c-5b30-434c-82cb-2140761c52d8" />

I originally tried using a vertically centred ellipsis (Ux22EF), on the basis that this would be more obviously distinct from an address that had been entered as "1...20", but this resulted in font issues (at least on my setup):

<img width="462" height="170" alt="image" src="https://github.com/user-attachments/assets/f47bafb9-d652-4a31-8077-d33ffd9edfd8" />

I suspect this is because the vertically centred ellipsis is the norm in Japanese typography and this unicode symbol may not be uniformly present in other Noto fonts. The "normal" ellipsis (Ux2026) is probably safer - we don't want to risk further mapnik font breakage.

For discussion:
- It looks slightly odd to, in effect, pretty-print `1;2;3` but not `1;2`. But since the goal is effective feedback rather than pretty-printing, I think this is OK. 
- We could abbreviate to `X;...;Y` to make the shortening-but-not-prettyprinting more explicit, but this would add width when the purpose is to reduce label size.
- ; as a separator is relatively unusual for `addr:housenumber` - the wiki recommends and it is more common to see comma separated list e.g. "1,2,3,4". Semi-colon lists do seem to be associated with the most egregious cases highlighted in #4155. In contrast, semi-colons are explicitly recommend for `addr:flats`. 
- It might be useful to add a length trigger, i.e. only consider shortening if 8+ characters.
