### PR TITLE
Distinguish railways crossings on less important railway types and prioritise crossings over text labels

### DIFF
--- a/indexes.sql
+++ b/indexes.sql
@@ -2,6 +2,7 @@
 -- This file is generated with scripts/indexes.py
 CREATE INDEX planet_osm_line_ferry ON planet_osm_line USING GIST (way) WHERE route = 'ferry' AND osm_id > 0;
 CREATE INDEX planet_osm_line_label ON planet_osm_line USING GIST (way) WHERE name IS NOT NULL OR (tags @> 'golf=>hole'::hstore AND ref IS NOT NULL);
+CREATE INDEX planet_osm_line_railway ON planet_osm_line USING GIST (way) WHERE railway IS NOT NULL;
 CREATE INDEX planet_osm_line_river ON planet_osm_line USING GIST (way) WHERE waterway = 'river';
 CREATE INDEX planet_osm_line_waterway ON planet_osm_line USING GIST (way) WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass');
 CREATE INDEX planet_osm_point_place ON planet_osm_point USING GIST (way) WHERE place IS NOT NULL AND name IS NOT NULL;

--- a/indexes.yml
+++ b/indexes.yml
@@ -11,6 +11,8 @@ line:
     where: name IS NOT NULL OR (tags @> 'golf=>hole'::hstore AND ref IS NOT NULL)
   ferry:
     where: route = 'ferry' AND osm_id > 0
+  railway:
+    where: railway IS NOT NULL
   river:
     where: waterway = 'river'
   waterway:

--- a/project.mml
+++ b/project.mml
@@ -1823,27 +1823,36 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-          crossing.way AS way,
-          crossing.railway AS type,
-          CASE
-            BOOL_AND(
-              track.railway IN ('disused', 'tram', 'miniature')
-              OR COALESCE(track.service IN ('spur', 'siding', 'yard'), FALSE)
-            ) FILTER (WHERE track.railway IS NOT NULL)
-            WHEN TRUE THEN 'yes'
-            WHEN FALSE THEN 'no'
-          END AS int_isminor,  -- NULL if no intersecting railways
-          crossing.osm_id
-        FROM planet_osm_point crossing
-        JOIN planet_osm_line track
-          ON ST_DWithin(crossing.way, track.way, 0.1)
-        WHERE crossing.railway IN ('crossing', 'level_crossing')
-          AND crossing.way && !bbox!
-          AND track.way && !bbox!
-        GROUP BY
-          crossing.osm_id,
-          crossing.way,
-          crossing.railway
+          *
+          FROM
+            (SELECT
+              crossing.way AS way,
+              crossing.railway AS railway,
+              CASE
+                BOOL_AND(
+                  track.railway IN ('disused', 'tram', 'miniature')
+                  OR COALESCE(track.service IN ('spur', 'siding', 'yard'), FALSE)
+                ) FILTER (WHERE track.railway IS NOT NULL)
+                WHEN TRUE THEN 'yes'
+                WHEN FALSE THEN 'no'
+              END AS int_isminor,  -- NULL if no intersecting railways
+              crossing.osm_id
+            FROM planet_osm_point crossing
+            JOIN planet_osm_line track
+              ON ST_DWithin(crossing.way, track.way, 0.1)
+            WHERE crossing.railway IN ('crossing', 'level_crossing')
+              AND ((track.railway IS NOT NULL) OR (track.highway IS NOT NULL))
+              AND crossing.way && !bbox!
+              AND track.way && !bbox!
+            GROUP BY
+              crossing.osm_id,
+              crossing.way,
+              crossing.railway
+            ) _
+          ORDER BY
+            CASE WHEN int_isminor IS NULL OR int_isminor = 'no' THEN 1 ELSE 2 END,
+            CASE WHEN railway = 'crossing' THEN 1 ELSE 2 END,
+            osm_id
         ) AS railway_crossings
     properties:
       minzoom: 14

--- a/project.mml
+++ b/project.mml
@@ -1829,8 +1829,9 @@ Layer:
               crossing.way AS way,
               crossing.railway AS railway,
               CASE
+                WHEN track.railway IS NULL THEN 'incomplete'
                 WHEN track.railway IN ('disused', 'tram', 'miniature') OR track.service IN ('spur', 'siding', 'yard') THEN 'yes'
-                ELSE 'no'  -- also returned if track.railway is NULL i.e. if no intersecting railway
+                ELSE 'no'
               END AS int_isminor,
               crossing.osm_id
             FROM planet_osm_point crossing
@@ -1841,7 +1842,10 @@ Layer:
               AND crossing.way && !bbox!
             ) _
           ORDER BY
-            CASE WHEN int_isminor = 'no' THEN 1 ELSE 2 END,
+            CASE int_isminor 
+              WHEN 'no' THEN 1
+              WHEN 'incomplete' THEN 2
+              ELSE 3 END,
             CASE WHEN railway = 'crossing' THEN 1 ELSE 2 END,
             osm_id
         ) AS railway_crossings

--- a/project.mml
+++ b/project.mml
@@ -1830,8 +1830,8 @@ Layer:
               crossing.railway AS railway,
               CASE
                 WHEN track.railway IN ('disused', 'tram', 'miniature') OR track.service IN ('spur', 'siding', 'yard') THEN 'yes'
-                ELSE 'no'
-              END AS int_isminor,  -- NULL if no intersecting railways
+                ELSE 'no'  -- also returned if track.railway is NULL i.e. if no intersecting railway
+              END AS int_isminor,
               crossing.osm_id
             FROM planet_osm_point crossing
             LEFT JOIN planet_osm_line track
@@ -1841,7 +1841,7 @@ Layer:
               AND crossing.way && !bbox!
             ) _
           ORDER BY
-            CASE WHEN int_isminor IS NULL OR int_isminor = 'no' THEN 1 ELSE 2 END,
+            CASE WHEN int_isminor = 'no' THEN 1 ELSE 2 END,
             CASE WHEN railway = 'crossing' THEN 1 ELSE 2 END,
             osm_id
         ) AS railway_crossings

--- a/project.mml
+++ b/project.mml
@@ -1816,6 +1816,37 @@ Layer:
         ) AS amenity_line
     properties:
       minzoom: 16
+  - id: railway-crossings
+    geometry: point
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+          crossing.way AS way,
+          crossing.railway AS type,
+          CASE
+            BOOL_AND(
+              track.railway IN ('disused', 'tram', 'miniature')
+              OR COALESCE(track.service IN ('spur', 'siding', 'yard'), FALSE)
+            ) FILTER (WHERE track.railway IS NOT NULL)
+            WHEN TRUE THEN 'yes'
+            WHEN FALSE THEN 'no'
+          END AS int_isminor,  -- NULL if no intersecting railways
+          crossing.osm_id
+        FROM planet_osm_point crossing
+        JOIN planet_osm_line track
+          ON ST_DWithin(crossing.way, track.way, 0.1)
+        WHERE crossing.railway IN ('crossing', 'level_crossing')
+          AND crossing.way && !bbox!
+          AND track.way && !bbox!
+        GROUP BY
+          crossing.osm_id,
+          crossing.way,
+          crossing.railway
+        ) AS railway_crossings
+    properties:
+      minzoom: 14
   - id: power-towers
     geometry: point
     <<: *extents
@@ -2329,7 +2360,6 @@ Layer:
             way,
             name,
             COALESCE(
-              'railway_' || CASE WHEN railway IN ('level_crossing', 'crossing') AND way_area IS NULL THEN railway END,
               'amenity_' || CASE WHEN amenity IN ('bench', 'waste_basket', 'waste_disposal') AND way_area IS NULL THEN amenity END,
               'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') AND way_area IS NULL THEN historic END,
               'man_made_' || CASE WHEN man_made IN ('cross') AND way_area IS NULL THEN man_made END,
@@ -2348,7 +2378,6 @@ Layer:
                   highway,
                   historic,
                   man_made,
-                  railway,
                   tags,
                   way_area
                 FROM planet_osm_polygon
@@ -2364,14 +2393,12 @@ Layer:
                   highway,
                   historic,
                   man_made,
-                  railway,
                   tags,
                   NULL::float AS way_area
                 FROM planet_osm_point
                 WHERE way && !bbox!
               ) _
-            WHERE railway IN ('level_crossing', 'crossing')
-               OR amenity IN ('bench', 'waste_basket', 'waste_disposal')
+            WHERE amenity IN ('bench', 'waste_basket', 'waste_disposal')
                OR historic IN ('wayside_cross', 'wayside_shrine')
                OR man_made IN ('cross')
                OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate')

--- a/project.mml
+++ b/project.mml
@@ -1829,25 +1829,16 @@ Layer:
               crossing.way AS way,
               crossing.railway AS railway,
               CASE
-                BOOL_AND(
-                  track.railway IN ('disused', 'tram', 'miniature')
-                  OR COALESCE(track.service IN ('spur', 'siding', 'yard'), FALSE)
-                ) FILTER (WHERE track.railway IS NOT NULL)
-                WHEN TRUE THEN 'yes'
-                WHEN FALSE THEN 'no'
+                WHEN track.railway IN ('disused', 'tram', 'miniature') OR track.service IN ('spur', 'siding', 'yard') THEN 'yes'
+                ELSE 'no'
               END AS int_isminor,  -- NULL if no intersecting railways
               crossing.osm_id
             FROM planet_osm_point crossing
-            JOIN planet_osm_line track
-              ON ST_DWithin(crossing.way, track.way, 0.1)
+            LEFT JOIN planet_osm_line track
+              ON track.railway IS NOT NULL
+              AND ST_DWithin(crossing.way, track.way, 0.1)
             WHERE crossing.railway IN ('crossing', 'level_crossing')
-              AND ((track.railway IS NOT NULL) OR (track.highway IS NOT NULL))
               AND crossing.way && !bbox!
-              AND track.way && !bbox!
-            GROUP BY
-              crossing.osm_id,
-              crossing.way,
-              crossing.railway
             ) _
           ORDER BY
             CASE WHEN int_isminor IS NULL OR int_isminor = 'no' THEN 1 ELSE 2 END,

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1498,6 +1498,21 @@
   }
 }
 
+#railway-crossings {
+  [type = 'level_crossing'][int_isminor != 'yes'],
+  [type = 'level_crossing'][zoom >= 16],
+  [type = 'crossing'][int_isminor != 'yes'][zoom >= 15],
+  [type = 'crossing'][zoom >= 16] {
+    marker-file: url('symbols/barrier/level_crossing.svg');
+    marker-fill: #4d4d4d;
+    marker-clip: false;
+    [int_isminor != 'yes'][zoom >= 16],
+    [zoom >= 17] {
+      marker-file: url('symbols/barrier/level_crossing2.svg');
+    }
+  }
+}
+
 #amenity-low-priority {
   [feature = 'man_made_cross'][zoom >= 16],
   [feature = 'historic_wayside_cross'][zoom >= 16] {
@@ -1510,16 +1525,6 @@
     marker-file: url('symbols/historic/shrine.svg');
     marker-fill: @man-made-icon;
     marker-clip: false;
-  }
-
-  [feature = 'railway_level_crossing'][zoom >= 14]::railway,
-  [feature = 'railway_crossing'][zoom >= 15]::railway{
-    marker-file: url('symbols/barrier/level_crossing.svg');
-    marker-fill: #4d4d4d;
-    marker-clip: false;
-    [zoom >= 16] {
-      marker-file: url('symbols/barrier/level_crossing2.svg');
-    }
   }
 
   [feature = 'barrier_gate']::barrier {

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1499,15 +1499,15 @@
 }
 
 #railway-crossings {
-  [type = 'level_crossing'][int_isminor != 'yes'],
-  [type = 'level_crossing'][zoom >= 16],
-  [type = 'crossing'][int_isminor != 'yes'][zoom >= 15],
-  [type = 'crossing'][zoom >= 16] {
+  [railway = 'level_crossing'][int_isminor != 'yes'],
+  [railway = 'level_crossing'][zoom >= 16],
+  [railway = 'crossing'][int_isminor != 'yes'][zoom >= 15],
+  [railway = 'crossing'][zoom >= 16] {
     marker-file: url('symbols/barrier/level_crossing.svg');
     marker-fill: #4d4d4d;
     marker-clip: false;
     [int_isminor != 'yes'][zoom >= 16],
-    [zoom >= 17] {
+    [zoom >= 18] {
       marker-file: url('symbols/barrier/level_crossing2.svg');
     }
   }

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1507,6 +1507,7 @@
     marker-fill: #4d4d4d;
     marker-clip: false;
     [int_isminor != 'yes'][zoom >= 16],
+    [railway = 'level_crossing'][zoom >= 17],
     [zoom >= 18] {
       marker-file: url('symbols/barrier/level_crossing2.svg');
     }

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1499,17 +1499,18 @@
 }
 
 #railway-crossings {
-  [railway = 'level_crossing'][int_isminor != 'yes'],
+  [railway = 'level_crossing'][int_isminor = 'no'],
   [railway = 'level_crossing'][zoom >= 16],
-  [railway = 'crossing'][int_isminor != 'yes'][zoom >= 15],
+  [railway = 'crossing'][int_isminor = 'no'][zoom >= 15],
   [railway = 'crossing'][zoom >= 16] {
     marker-file: url('symbols/barrier/level_crossing.svg');
     marker-fill: #4d4d4d;
     marker-clip: false;
-    [int_isminor != 'yes'][zoom >= 16],
+    [int_isminor = 'no'][zoom >= 16],
     [railway = 'level_crossing'][zoom >= 17],
     [zoom >= 18] {
       marker-file: url('symbols/barrier/level_crossing2.svg');
+      [int_isminor = 'incomplete'] { marker-file: url('symbols/barrier/level_crossing_incomplete.svg'); }
     }
   }
 }

--- a/symbols/barrier/level_crossing_incomplete.svg
+++ b/symbols/barrier/level_crossing_incomplete.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="11" height="11"
+     viewBox="0 0 11 11">
+  <rect
+     id="mapnik_workaround"
+     width="11" height="11"
+     fill="none" />
+  <path
+    stroke="#ffffff" stroke-width="0.7"
+    d="M 0.65 0.65 L 0.65 2.35 L 2.65 4.35 L 4.35 4.35 L 4.35 2.65 L 2.35 0.65 Z"/>
+  <path
+    stroke="#ffffff" stroke-width="0.7"
+    d="M 8.65 0.65 L 6.65 2.65 L 6.65 4.35 L 8.35 4.35 L 10.35 2.35 L 10.35 0.65 Z"/>
+  <path
+    stroke="#ffffff" stroke-width="0.7"
+    d="M 2.65 6.65 L 0.65 8.65 L 0.65 10.35 L 2.35 10.35 L 4.35 8.35 L 4.35 6.65 Z"/>
+  <path
+    stroke="#ffffff" stroke-width="0.7"
+    d="M 6.65 6.65 L 6.65 8.35 L 8.65 10.35 L 10.35 10.35 L 10.35 8.65 L 8.35 6.65 Z"/>
+</svg>


### PR DESCRIPTION
Closes #4559 
Closes #4579 
Fixes #4850

Changes proposed in this pull request:
- Performs a spatial join of railway crossing node with "intersecting" ways to distinguish railways crossings by the `railway` involved.
- A crossing is deemed to be "minor" if the railway is involved is either `disused`, `miniature` or `tram`, or if the `service` is tag is one of `spur`, `siding`, `yard`.
- ~~If no railways intersect, the crossing is still rendered but `int_isminor` is `NULL` to allow this case to be rendered differently. The MSS currently treats this as a "major" crossing for good visibility.~~
- "Minor crossings" are not rendered until Z16+, and the larger crossing symbol only used for Z17+ (level crossings) or Z18+ (pedestrian crossing).
- "Major crossings" are rendered as currently, i.e. small symbol from Z14, larger symbol from Z16.
- "Major crossings" are prioritised over minor crossings.
- New railway crossings query has been moved up conservatively to after the main amenity POI queries and before power towers (i.e. ahead of all text labels).

~~Notes~~
- ~~The SQL query is a bit unusual. The turning circle query uses `SELECT DISTINCT ON(way)`. Here we want to order the rows so that all the "major" crossings come first, which is incompatible with `SELECT DISTINCT` on the way/osm_id. Instead `GROUP BY` and aggregation is used to determine the major/minor type.~~

[Test sheet]
Before Z14
<img width="67" height="80" alt="image" src="https://github.com/user-attachments/assets/a97a86de-e40e-4af1-9a08-8e341b97722c" />

(railways are: None, `rail`, spur `rail`, `tram`, `disused`, `miniature`, `rail` + `tram`)

After Z14
<img width="66" height="79" alt="image" src="https://github.com/user-attachments/assets/c1e93660-e873-4d7f-b57b-d2327fa60463" />

Before Z15:
<img width="134" height="154" alt="image" src="https://github.com/user-attachments/assets/88eb829b-38fc-453e-9c1f-e6acbbdff344" />

After Z15:
<img width="133" height="158" alt="image" src="https://github.com/user-attachments/assets/18344885-21bd-4bdc-8458-47730e933b09" />

Before Z16:
<img width="240" height="289" alt="image" src="https://github.com/user-attachments/assets/8829c0bb-5c65-43ac-9d94-9159ed88219a" />

After Z16:
<img width="262" height="285" alt="image" src="https://github.com/user-attachments/assets/304841e9-1c7f-4aab-a6a7-cf9a5f5e1a7c" />

After Z17: ~~(current behaviour)~~ As current behaviour, except `railway=crossing` on a "minor railway" has a small symbol.
<img width="429" height="551" alt="image" src="https://github.com/user-attachments/assets/85bf49fd-3559-4294-88c1-2f8cc4c2a018" />

Test of re-prioritisation [here](https://www.openstreetmap.org/#map=14/54.85105/-1.37891), 

Z15:
<img width="127" height="92" alt="Image" src="https://github.com/user-attachments/assets/2b7fd718-609f-4f3d-978d-478df26f7720" />

After:
<img width="107" height="63" alt="image" src="https://github.com/user-attachments/assets/94ca6d17-d960-42c0-bec7-e5ad4e5cde77" />

Crossings on [miniature railway](https://www.openstreetmap.org/#map=15/55.00275/-1.41515):

Before Z14:
<img width="60" height="44" alt="image" src="https://github.com/user-attachments/assets/f83f349c-5865-41c1-866e-ca2486700ce8" />

After Z14:
<img width="63" height="47" alt="image" src="https://github.com/user-attachments/assets/8596f0b8-3ff3-4564-903a-7ddec0b39fb4" />

Before Z15:
<img width="107" height="80" alt="image" src="https://github.com/user-attachments/assets/c726c45d-59aa-4cd3-8064-3739e3fd91a3" />

After Z15:
<img width="104" height="83" alt="image" src="https://github.com/user-attachments/assets/5cef2fc9-bb7b-4638-a4ef-1b56fd0c50c5" />

Before Z16:
<img width="218" height="166" alt="image" src="https://github.com/user-attachments/assets/cac3b67c-2f3b-48e1-9db9-b865e613c266" />

After Z16:
<img width="219" height="173" alt="image" src="https://github.com/user-attachments/assets/87575110-3d79-45cf-89e1-f9fbdc065c84" />
