### PR TITLE
Fix bridge regression

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -214,6 +214,7 @@ Layer:
             CASE WHEN int_bridge_tunnel = 'tunnel' THEN 1 ELSE 0 END  -- render tunnels after normal waterways (bridges are in later layer)
         ) AS water_lines
     properties:
+      cache-features: true
       minzoom: 12
   - id: water-areas
     geometry: polygon

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -336,6 +336,13 @@
 
 @railway-text-repeat-distance: 200;
 
+// Ensures that the 4 attachments in the tunnels layer are always correctly ordered 
+// (Equivalent for bridges layer is in water.mss)
+#tunnels[feature = null]::halo { line: none; }
+#tunnels[feature = null]::casing { line: none; }
+#tunnels[feature = null]::bridges_and_tunnels_background { line: none; }
+#tunnels[feature = null]::fill { line: none; }
+
 #roads-casing, #bridges, #tunnels {
   ::casing {
     [zoom >= 12] {

--- a/style/water.mss
+++ b/style/water.mss
@@ -75,6 +75,12 @@
   }
 }
 
+// Ensure that the 4 attachments in the bridges layer are always correctly ordered
+#bridges[feature = null]::halo { line: none; }
+#bridges[feature = null]::casing { line: none; }
+#bridges[feature = null]::bridges_and_tunnels_background { line: none; }
+#bridges[feature = null]::fill { line: none; }
+
 #water-lines::casing {
   // white glow used when water stroke width is less than 3.5 px and only at "mid zoom" (13 - 17)
 
@@ -157,14 +163,7 @@
   }
 }
 
-// Dummy attachment so that waterway bridges has the same 3 attachments as bridges in roads.mss
-#bridges::bridges_and_tunnels_background {
-  [feature = null] {
-    line: none;
-  }
-}
-
-#water-lines,
+#water-lines::fill,
 #bridges::fill {
   [feature = 'waterway_river'][zoom >= 12] {
     [int_bridge_tunnel = 'tunnel'] {

--- a/style/water.mss
+++ b/style/water.mss
@@ -157,6 +157,13 @@
   }
 }
 
+// Dummy attachment so that waterway bridges has the same 3 attachments as bridges in roads.mss
+#bridges::bridges_and_tunnels_background {
+  [feature = null] {
+    line: none;
+  }
+}
+
 #water-lines,
 #bridges::fill {
   [feature = 'waterway_river'][zoom >= 12] {


### PR DESCRIPTION
Fixes #5284 

Changes proposed in this pull request:
- Introduce dummy attachment in water.mss so that waterway bridges have the same 3 attachments as bridges defined in roads.mss

Test rendering with links to the example places:

Before
<img width="298" height="329" alt="image" src="https://github.com/user-attachments/assets/3b1d4150-ff55-4bb2-a71c-4297e78b28fe" />

After
<img width="297" height="333" alt="image" src="https://github.com/user-attachments/assets/60b1d02b-3719-4a4c-a681-fcff30505a76" />

[Added test lines are `railway=rail` + `layer=1` and `highway=cycleway`]

The railway and cycleway ::fill attachment is now correctly appearing after ::bridges_and_tunnels_background.

Note that a complete empty attachment (no `[feature=null]` selector) does not work i.e. is presumably ignored by carto.
 