### PR TITLE
Lighten minor railways

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -491,10 +491,11 @@ Layer:
                 way,
                 'railway_' || (CASE
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 -- minor trackage of every railway class except rail shares one thin signature;
+                                 WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
+                                 -- minor trackage of the other railway classes shares the tram-service signature;
                                  -- subway keeps its lighter colour so it stays distinguishable from light_rail
                                  WHEN (railway = 'subway' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-subway'
-                                 WHEN (railway IN ('tram', 'light_rail', 'funicular', 'narrow_gauge', 'monorail')
+                                 WHEN (railway IN ('light_rail', 'funicular', 'narrow_gauge', 'monorail')
                                        AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-railway'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
@@ -518,7 +519,7 @@ Layer:
             layernotnull,
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_INT-minor-railway', 'railway_INT-minor-subway') THEN 0 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service', 'railway_INT-minor-railway', 'railway_INT-minor-subway') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id
@@ -739,10 +740,11 @@ Layer:
                 way,
                 'railway_' || (CASE
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 -- minor trackage of every railway class except rail shares one thin signature;
+                                 WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
+                                 -- minor trackage of the other railway classes shares the tram-service signature;
                                  -- subway keeps its lighter colour so it stays distinguishable from light_rail
                                  WHEN (railway = 'subway' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-subway'
-                                 WHEN (railway IN ('tram', 'light_rail', 'funicular', 'narrow_gauge', 'monorail')
+                                 WHEN (railway IN ('light_rail', 'funicular', 'narrow_gauge', 'monorail')
                                        AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-railway'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
@@ -769,7 +771,7 @@ Layer:
             layernotnull,
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_INT-minor-railway', 'railway_INT-minor-subway') THEN 0 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service', 'railway_INT-minor-railway', 'railway_INT-minor-subway') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id
@@ -908,10 +910,11 @@ Layer:
                 way,
                 'railway_' || (CASE
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 -- minor trackage of every railway class except rail shares one thin signature;
+                                 WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
+                                 -- minor trackage of the other railway classes shares the tram-service signature;
                                  -- subway keeps its lighter colour so it stays distinguishable from light_rail
                                  WHEN (railway = 'subway' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-subway'
-                                 WHEN (railway IN ('tram', 'light_rail', 'funicular', 'narrow_gauge', 'monorail')
+                                 WHEN (railway IN ('light_rail', 'funicular', 'narrow_gauge', 'monorail')
                                        AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-railway'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
@@ -958,7 +961,7 @@ Layer:
             layernotnull,
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_INT-minor-railway', 'railway_INT-minor-subway') THEN 0 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service', 'railway_INT-minor-railway', 'railway_INT-minor-subway') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id

--- a/project.mml
+++ b/project.mml
@@ -496,7 +496,7 @@ Layer:
                 NULL AS int_surface,
                 NULL AS int_access,
                 construction,
-                NULL AS service,
+                CASE WHEN service IN ('spur', 'siding', 'yard') THEN 'INT-minor' END AS service,
                 NULL AS link,
                 CASE
                   WHEN tags->'railway:preserved' = 'yes' THEN 'yes'
@@ -740,7 +740,7 @@ Layer:
                 NULL AS int_surface,
                 NULL AS int_access,
                 construction,
-                NULL AS service,
+                CASE WHEN service IN ('spur', 'siding', 'yard') THEN 'INT-minor' END AS service,
                 NULL AS link,
                 CASE
                   WHEN tags->'railway:preserved' = 'yes' THEN 'yes'
@@ -905,7 +905,7 @@ Layer:
                 NULL AS int_surface,
                 NULL AS int_access,
                 construction,
-                NULL AS service,
+                CASE WHEN service IN ('spur', 'siding', 'yard') THEN 'INT-minor' END AS service,
                 NULL AS link,
                 CASE
                   WHEN tags->'railway:preserved' = 'yes' THEN 'yes'

--- a/project.mml
+++ b/project.mml
@@ -491,8 +491,10 @@ Layer:
                 way,
                 'railway_' || (CASE
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 -- minor trackage of every railway class except rail shares one signature
-                                 WHEN (railway IN ('tram', 'light_rail', 'subway', 'funicular', 'narrow_gauge', 'monorail')
+                                 -- minor trackage of every railway class except rail shares one thin signature;
+                                 -- subway keeps its lighter colour so it stays distinguishable from light_rail
+                                 WHEN (railway = 'subway' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-subway'
+                                 WHEN (railway IN ('tram', 'light_rail', 'funicular', 'narrow_gauge', 'monorail')
                                        AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-railway'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
@@ -516,7 +518,7 @@ Layer:
             layernotnull,
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_INT-minor-railway') THEN 0 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_INT-minor-railway', 'railway_INT-minor-subway') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id
@@ -737,8 +739,10 @@ Layer:
                 way,
                 'railway_' || (CASE
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 -- minor trackage of every railway class except rail shares one signature
-                                 WHEN (railway IN ('tram', 'light_rail', 'subway', 'funicular', 'narrow_gauge', 'monorail')
+                                 -- minor trackage of every railway class except rail shares one thin signature;
+                                 -- subway keeps its lighter colour so it stays distinguishable from light_rail
+                                 WHEN (railway = 'subway' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-subway'
+                                 WHEN (railway IN ('tram', 'light_rail', 'funicular', 'narrow_gauge', 'monorail')
                                        AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-railway'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
@@ -765,7 +769,7 @@ Layer:
             layernotnull,
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_INT-minor-railway') THEN 0 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_INT-minor-railway', 'railway_INT-minor-subway') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id
@@ -904,8 +908,10 @@ Layer:
                 way,
                 'railway_' || (CASE
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 -- minor trackage of every railway class except rail shares one signature
-                                 WHEN (railway IN ('tram', 'light_rail', 'subway', 'funicular', 'narrow_gauge', 'monorail')
+                                 -- minor trackage of every railway class except rail shares one thin signature;
+                                 -- subway keeps its lighter colour so it stays distinguishable from light_rail
+                                 WHEN (railway = 'subway' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-subway'
+                                 WHEN (railway IN ('tram', 'light_rail', 'funicular', 'narrow_gauge', 'monorail')
                                        AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-railway'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
@@ -952,7 +958,7 @@ Layer:
             layernotnull,
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_INT-minor-railway') THEN 0 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_INT-minor-railway', 'railway_INT-minor-subway') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id

--- a/project.mml
+++ b/project.mml
@@ -214,6 +214,7 @@ Layer:
             CASE WHEN int_bridge_tunnel = 'tunnel' THEN 1 ELSE 0 END  -- render tunnels after normal waterways (bridges are in later layer)
         ) AS water_lines
     properties:
+      cache-features: true
       minzoom: 12
   - id: water-areas
     geometry: polygon
@@ -490,13 +491,15 @@ Layer:
                 way,
                 'railway_' || (CASE
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
+                                 -- light_rail, funicular and narrow_gauge use the tram rendering
+                                 WHEN (railway IN ('tram', 'light_rail', 'funicular', 'narrow_gauge') AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
+                                 WHEN (railway IN ('light_rail', 'funicular', 'narrow_gauge')) THEN 'tram'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
                 NULL AS int_surface,
                 NULL AS int_access,
                 construction,
-                CASE WHEN service IN ('spur', 'siding', 'yard') THEN 'INT-minor' END AS service,
+                NULL AS service,
                 NULL AS link,
                 CASE
                   WHEN tags->'railway:preserved' = 'yes' THEN 'yes'
@@ -734,13 +737,15 @@ Layer:
                 way,
                 'railway_' || (CASE
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
+                                 -- light_rail, funicular and narrow_gauge use the tram rendering
+                                 WHEN (railway IN ('tram', 'light_rail', 'funicular', 'narrow_gauge') AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
+                                 WHEN (railway IN ('light_rail', 'funicular', 'narrow_gauge')) THEN 'tram'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
                 NULL AS int_surface,
                 NULL AS int_access,
                 construction,
-                CASE WHEN service IN ('spur', 'siding', 'yard') THEN 'INT-minor' END AS service,
+                NULL AS service,
                 NULL AS link,
                 CASE
                   WHEN tags->'railway:preserved' = 'yes' THEN 'yes'
@@ -832,7 +837,7 @@ Layer:
             carto_highway_int_surface(surface) AS int_surface
           FROM planet_osm_roads
           WHERE highway IS NOT NULL
-            OR (railway IN ('rail', 'light_rail', 'funicular', 'narrow_gauge')
+            OR (railway = 'rail'
               AND (tags->'railway:preserved' IS NULL OR tags->'railway:preserved' != 'yes')
               AND (service IS NULL OR service NOT IN ('spur', 'siding', 'yard')))
           ORDER BY
@@ -899,13 +904,15 @@ Layer:
                 way,
                 'railway_' || (CASE
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
+                                 -- light_rail, funicular and narrow_gauge use the tram rendering
+                                 WHEN (railway IN ('tram', 'light_rail', 'funicular', 'narrow_gauge') AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
+                                 WHEN (railway IN ('light_rail', 'funicular', 'narrow_gauge')) THEN 'tram'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
                 NULL AS int_surface,
                 NULL AS int_access,
                 construction,
-                CASE WHEN service IN ('spur', 'siding', 'yard') THEN 'INT-minor' END AS service,
+                NULL AS service,
                 NULL AS link,
                 CASE
                   WHEN tags->'railway:preserved' = 'yes' THEN 'yes'
@@ -2164,7 +2171,7 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       # Include values that are rendered as icon without label to prevent mismatch between icons and labels,
-      # see https://github.com/gravitystorm/openstreetmap-carto/pull/1349#issuecomment-77805678
+      # see https://github.com/openstreetmap-carto/openstreetmap-carto/pull/1349#issuecomment-77805678
       table: *amenity_points_sql
     properties:
       minzoom: 10
@@ -2393,7 +2400,7 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       # Include values that are rendered as icon without label to prevent mismatch between icons and labels,
-      # see https://github.com/gravitystorm/openstreetmap-carto/pull/1349#issuecomment-77805678
+      # see https://github.com/openstreetmap-carto/openstreetmap-carto/pull/1349#issuecomment-77805678
       table: *amenity_low_priority_sql
     properties:
       minzoom: 17

--- a/project.mml
+++ b/project.mml
@@ -491,9 +491,9 @@ Layer:
                 way,
                 'railway_' || (CASE
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 -- light_rail, funicular and narrow_gauge use the tram rendering
-                                 WHEN (railway IN ('tram', 'light_rail', 'funicular', 'narrow_gauge') AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
-                                 WHEN (railway IN ('light_rail', 'funicular', 'narrow_gauge')) THEN 'tram'
+                                 -- minor trackage of every railway class except rail shares one signature
+                                 WHEN (railway IN ('tram', 'light_rail', 'subway', 'funicular', 'narrow_gauge', 'monorail')
+                                       AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-railway'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
                 NULL AS int_surface,
@@ -516,7 +516,7 @@ Layer:
             layernotnull,
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_INT-minor-railway') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id
@@ -737,9 +737,9 @@ Layer:
                 way,
                 'railway_' || (CASE
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 -- light_rail, funicular and narrow_gauge use the tram rendering
-                                 WHEN (railway IN ('tram', 'light_rail', 'funicular', 'narrow_gauge') AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
-                                 WHEN (railway IN ('light_rail', 'funicular', 'narrow_gauge')) THEN 'tram'
+                                 -- minor trackage of every railway class except rail shares one signature
+                                 WHEN (railway IN ('tram', 'light_rail', 'subway', 'funicular', 'narrow_gauge', 'monorail')
+                                       AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-railway'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
                 NULL AS int_surface,
@@ -765,7 +765,7 @@ Layer:
             layernotnull,
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_INT-minor-railway') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id
@@ -837,7 +837,7 @@ Layer:
             carto_highway_int_surface(surface) AS int_surface
           FROM planet_osm_roads
           WHERE highway IS NOT NULL
-            OR (railway = 'rail'
+            OR (railway IN ('rail', 'light_rail', 'funicular', 'narrow_gauge')
               AND (tags->'railway:preserved' IS NULL OR tags->'railway:preserved' != 'yes')
               AND (service IS NULL OR service NOT IN ('spur', 'siding', 'yard')))
           ORDER BY
@@ -904,9 +904,9 @@ Layer:
                 way,
                 'railway_' || (CASE
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 -- light_rail, funicular and narrow_gauge use the tram rendering
-                                 WHEN (railway IN ('tram', 'light_rail', 'funicular', 'narrow_gauge') AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
-                                 WHEN (railway IN ('light_rail', 'funicular', 'narrow_gauge')) THEN 'tram'
+                                 -- minor trackage of every railway class except rail shares one signature
+                                 WHEN (railway IN ('tram', 'light_rail', 'subway', 'funicular', 'narrow_gauge', 'monorail')
+                                       AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-railway'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
                 NULL AS int_surface,
@@ -952,7 +952,7 @@ Layer:
             layernotnull,
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_INT-minor-railway') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id

--- a/project.mml
+++ b/project.mml
@@ -490,13 +490,9 @@ Layer:
             SELECT
                 way,
                 'railway_' || (CASE
-                                 WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
-                                 -- minor trackage of the other railway classes shares the tram-service signature;
-                                 -- subway keeps its lighter colour so it stays distinguishable from light_rail
-                                 WHEN (railway = 'subway' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-subway'
-                                 WHEN (railway IN ('light_rail', 'funicular', 'narrow_gauge', 'monorail')
-                                       AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-railway'
+                                 -- spur/siding/yard tracks get a feature per railway class, e.g. INT-light_rail-service
+                                 WHEN (railway IN ('rail', 'tram', 'light_rail', 'subway', 'funicular', 'narrow_gauge', 'monorail')
+                                       AND service IN ('spur', 'siding', 'yard')) THEN 'INT-' || railway || '-service'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
                 NULL AS int_surface,
@@ -519,7 +515,8 @@ Layer:
             layernotnull,
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service', 'railway_INT-minor-railway', 'railway_INT-minor-subway') THEN 0 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-rail-service', 'railway_INT-tram-service', 'railway_INT-light_rail-service', 'railway_INT-subway-service',
+                                  'railway_INT-funicular-service', 'railway_INT-narrow_gauge-service', 'railway_INT-monorail-service') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id
@@ -739,13 +736,9 @@ Layer:
             SELECT
                 way,
                 'railway_' || (CASE
-                                 WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
-                                 -- minor trackage of the other railway classes shares the tram-service signature;
-                                 -- subway keeps its lighter colour so it stays distinguishable from light_rail
-                                 WHEN (railway = 'subway' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-subway'
-                                 WHEN (railway IN ('light_rail', 'funicular', 'narrow_gauge', 'monorail')
-                                       AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-railway'
+                                 -- spur/siding/yard tracks get a feature per railway class, e.g. INT-light_rail-service
+                                 WHEN (railway IN ('rail', 'tram', 'light_rail', 'subway', 'funicular', 'narrow_gauge', 'monorail')
+                                       AND service IN ('spur', 'siding', 'yard')) THEN 'INT-' || railway || '-service'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
                 NULL AS int_surface,
@@ -771,7 +764,8 @@ Layer:
             layernotnull,
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service', 'railway_INT-minor-railway', 'railway_INT-minor-subway') THEN 0 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-rail-service', 'railway_INT-tram-service', 'railway_INT-light_rail-service', 'railway_INT-subway-service',
+                                  'railway_INT-funicular-service', 'railway_INT-narrow_gauge-service', 'railway_INT-monorail-service') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id
@@ -909,13 +903,9 @@ Layer:
             SELECT
                 way,
                 'railway_' || (CASE
-                                 WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
-                                 -- minor trackage of the other railway classes shares the tram-service signature;
-                                 -- subway keeps its lighter colour so it stays distinguishable from light_rail
-                                 WHEN (railway = 'subway' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-subway'
-                                 WHEN (railway IN ('light_rail', 'funicular', 'narrow_gauge', 'monorail')
-                                       AND service IN ('spur', 'siding', 'yard')) THEN 'INT-minor-railway'
+                                 -- spur/siding/yard tracks get a feature per railway class, e.g. INT-light_rail-service
+                                 WHEN (railway IN ('rail', 'tram', 'light_rail', 'subway', 'funicular', 'narrow_gauge', 'monorail')
+                                       AND service IN ('spur', 'siding', 'yard')) THEN 'INT-' || railway || '-service'
                                  ELSE railway END) AS feature,
                 NULL AS tracktype,
                 NULL AS int_surface,
@@ -961,7 +951,8 @@ Layer:
             layernotnull,
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service', 'railway_INT-minor-railway', 'railway_INT-minor-subway') THEN 0 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-rail-service', 'railway_INT-tram-service', 'railway_INT-light_rail-service', 'railway_INT-subway-service',
+                                  'railway_INT-funicular-service', 'railway_INT-narrow_gauge-service', 'railway_INT-monorail-service') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id
@@ -2038,8 +2029,8 @@ Layer:
         (SELECT
             way,
             CASE
-              WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-              WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
+              WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-rail-service'
+              WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-tram-service'
               ELSE railway
             END AS railway,
             tags->'highspeed' as highspeed,

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -336,6 +336,13 @@
 
 @railway-text-repeat-distance: 200;
 
+// Ensures that the 4 attachments in the tunnels layer are always correctly ordered 
+// (Equivalent for bridges layer is in water.mss)
+#tunnels[feature = null]::halo { line: none; }
+#tunnels[feature = null]::casing { line: none; }
+#tunnels[feature = null]::bridges_and_tunnels_background { line: none; }
+#tunnels[feature = null]::fill { line: none; }
+
 #roads-casing, #bridges, #tunnels {
   ::casing {
     [zoom >= 12] {
@@ -829,18 +836,6 @@
       }
     }
 
-    [feature = 'railway_light_rail'],
-    [feature = 'railway_funicular'],
-    [feature = 'railway_narrow_gauge'] {
-      #bridges {
-        [zoom >= 14] {
-          line-width: 5.5;
-          line-color: @bridge-casing;
-          line-join: round;
-        }
-      }
-    }
-
     [feature = 'railway_rail'],
     [feature = 'railway_monorail'][zoom >= 14] {
       #bridges {
@@ -1094,18 +1089,6 @@
         }
       }
     }
-
-    [feature = 'railway_light_rail'],
-    [feature = 'railway_funicular'],
-    [feature = 'railway_narrow_gauge'] {
-      #bridges {
-        [zoom >= 14] {
-          line-width: 4;
-          line-color: white;
-          line-join: round;
-        }
-      }
-    }
   }
 }
 
@@ -1185,7 +1168,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     /*
      * The highway_construction rules below are quite sensitive to re-ordering, since the instances end up swapping round
      * (and then the dashes appear below the fills). See:
-     * https://github.com/gravitystorm/openstreetmap-carto/issues/23
+     * https://github.com/openstreetmap-carto/openstreetmap-carto/issues/23
      * https://github.com/mapbox/carto/issues/235
      * https://github.com/mapbox/carto/issues/237
      */
@@ -2641,40 +2624,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
             line-dasharray: 8,6;
             line-width: 3.8;
           }
-        }
-      }
-    }
-
-    [feature = 'railway_light_rail'],
-    [feature = 'railway_funicular'],
-    [feature = 'railway_narrow_gauge'] {
-      [zoom >= 8][zoom < 10],
-      [preserved != 'yes'][zoom >= 10][zoom < 12],
-      [zoom >= 12] {
-        line-color: #ccc;
-        [zoom >= 10] { line-color: #aaa; }
-        [zoom >= 13] {
-          line-color: #666;
-          /* Spur, siding and yard trackage is de-emphasised relative to running lines */
-          [service = 'INT-minor'] { line-color: #999; }
-        }
-        line-width: 1;
-        [zoom >= 13] {
-          line-width: 2;
-          [service = 'INT-minor'] { line-width: 1; }
-        }
-        [preserved = 'yes'][zoom >= 13] {
-          #roads-fill, #bridges {
-            dark/line-width: 3;
-            dark/line-color: #999;
-            light/line-width: 1;
-            light/line-color: white;
-            light/line-dasharray: 0,1,8,1;
-            light/line-join: round;
-          }
-        }
-        #tunnels {
-          line-dasharray: 5,3;
         }
       }
     }
@@ -4363,7 +4312,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
   /*
   Other minor railway styles. For service rails, see:
-  https://github.com/gravitystorm/openstreetmap-carto/pull/2687
+  https://github.com/openstreetmap-carto/openstreetmap-carto/pull/2687
   */
   [railway = 'miniature'],
   [railway = 'disused'],

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -824,6 +824,7 @@
       }
     }
 
+    [feature = 'railway_tram-service'][zoom >= 15],
     [feature = 'railway_INT-minor-railway'],
     [feature = 'railway_INT-minor-subway'] {
       #bridges {
@@ -1103,6 +1104,7 @@
       }
     }
 
+    [feature = 'railway_tram-service'][zoom >= 15],
     [feature = 'railway_INT-minor-railway'],
     [feature = 'railway_INT-minor-subway'] {
       #bridges {
@@ -2729,8 +2731,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     /* Minor trackage (service=spur/siding/yard) of every railway class except
-    railway=rail shares a single thin signature, so that the distinction
-    between the classes is drawn on the main tracks only. */
+    railway=rail shares the thin tram-service signature, so that the distinction
+    between the classes is drawn on the main tracks only. Tram keeps its
+    established z15 start; the other classes begin at z14. */
+    [feature = 'railway_tram-service'][zoom >= 15],
     [feature = 'railway_INT-minor-railway'],
     [feature = 'railway_INT-minor-subway'] {
       [zoom >= 14] {

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -811,8 +811,20 @@
       }
     }
 
-    [feature = 'railway_tram'],
-    [feature = 'railway_tram-service'][zoom >= 15] {
+    [feature = 'railway_tram'] {
+      #bridges {
+        [zoom >= 13] {
+          line-width: 4;
+          [zoom >= 15] {
+            line-width: 5;
+          }
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'railway_INT-minor-railway'] {
       #bridges {
         [zoom >= 13] {
           line-width: 4;
@@ -827,6 +839,18 @@
 
     [feature = 'railway_subway'],
     [feature = 'railway_construction'][construction = 'subway'] {
+      #bridges {
+        [zoom >= 14] {
+          line-width: 5.5;
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'railway_light_rail'],
+    [feature = 'railway_funicular'],
+    [feature = 'railway_narrow_gauge'] {
       #bridges {
         [zoom >= 14] {
           line-width: 5.5;
@@ -1066,8 +1090,19 @@
       }
     }
 
-    [feature = 'railway_tram'],
-    [feature = 'railway_tram-service'][zoom >= 15] {
+    [feature = 'railway_tram'] {
+      #bridges {
+        [zoom >= 13] {
+          line-width: 3;
+          [zoom >= 15] {
+            line-width: 4;
+          }
+          line-color: white;
+        }
+      }
+    }
+
+    [feature = 'railway_INT-minor-railway'] {
       #bridges {
         [zoom >= 13] {
           line-width: 3;
@@ -1081,6 +1116,18 @@
 
     [feature = 'railway_subway'],
     [feature = 'railway_construction'][construction = 'subway'] {
+      #bridges {
+        [zoom >= 14] {
+          line-width: 4;
+          line-color: white;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'railway_light_rail'],
+    [feature = 'railway_funicular'],
+    [feature = 'railway_narrow_gauge'] {
       #bridges {
         [zoom >= 14] {
           line-width: 4;
@@ -2628,6 +2675,33 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       }
     }
 
+    [feature = 'railway_light_rail'],
+    [feature = 'railway_funicular'],
+    [feature = 'railway_narrow_gauge'] {
+      [zoom >= 8][zoom < 10],
+      [preserved != 'yes'][zoom >= 10][zoom < 12],
+      [zoom >= 12] {
+        line-color: #ccc;
+        [zoom >= 10] { line-color: #aaa; }
+        [zoom >= 13] { line-color: #666; }
+        line-width: 1;
+        [zoom >= 13] { line-width: 2; }
+        [preserved = 'yes'][zoom >= 13] {
+          #roads-fill, #bridges {
+            dark/line-width: 3;
+            dark/line-color: #999;
+            light/line-width: 1;
+            light/line-color: white;
+            light/line-dasharray: 0,1,8,1;
+            light/line-join: round;
+          }
+        }
+        #tunnels {
+          line-dasharray: 5,3;
+        }
+      }
+    }
+
     [feature = 'railway_miniature'] {
       [zoom >= 15] {
         line/line-width: 1.2;
@@ -2647,8 +2721,35 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       }
     }
 
-    [feature = 'railway_tram'],
-    [feature = 'railway_tram-service'][zoom >= 15] {
+    /* Minor trackage (service=spur/siding/yard) of every railway class except
+    railway=rail shares a single thin, light signature, so that the distinction
+    between the classes is drawn on the main tracks only. */
+    [feature = 'railway_INT-minor-railway'] {
+      [zoom >= 12] {
+        line-color: #aaa;
+        line-width: 0.5;
+        [zoom >= 14] {
+          line-width: 0.75;
+        }
+        [zoom >= 15] {
+          line-width: 1;
+        }
+        [zoom >= 17] {
+          line-width: 1.25;
+        }
+        [zoom >= 18] {
+          line-width: 1.5;
+        }
+        [zoom >= 19] {
+          line-width: 2;
+        }
+        #tunnels {
+          line-dasharray: 5,3;
+        }
+      }
+    }
+
+    [feature = 'railway_tram'] {
       [zoom >= 12] {
         line-color: #6E6E6E;
         line-width: 0.75;
@@ -2657,25 +2758,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         }
         [zoom >= 15] {
           line-width: 1.5;
-          [feature = 'railway_tram-service'] {
-            line-width: 0.5;
-          }
         }
         [zoom >= 17] {
           line-width: 2;
-          [feature = 'railway_tram-service'] {
-            line-width: 1;
-          }
-        }
-        [zoom >= 18] {
-          [feature = 'railway_tram-service'] {
-            line-width: 1.5;
-          }
-        }
-        [zoom >= 19] {
-          [feature = 'railway_tram-service'] {
-            line-width: 2;
-          }
         }
         [preserved = 'yes'][zoom >= 15] {
           #roads-fill, #bridges {

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2653,7 +2653,11 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [zoom >= 12] {
         line-color: #ccc;
         [zoom >= 10] { line-color: #aaa; }
-        [zoom >= 13] { line-color: #666; }
+        [zoom >= 13] {
+          line-color: #666;
+          /* Spur, siding and yard trackage is de-emphasised relative to running lines */
+          [service = 'INT-minor'] { line-color: #999; }
+        }
         line-width: 1;
         [zoom >= 13] { line-width: 2; }
         [preserved = 'yes'][zoom >= 13] {

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2726,16 +2726,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     between the classes is drawn on the main tracks only. */
     [feature = 'railway_INT-minor-railway'] {
       [zoom >= 12] {
-        line-color: #aaa;
+        line-color: #6E6E6E;
         line-width: 0.5;
-        [zoom >= 14] {
-          line-width: 0.75;
-        }
-        [zoom >= 15] {
-          line-width: 1;
-        }
         [zoom >= 17] {
-          line-width: 1.25;
+          line-width: 1;
         }
         [zoom >= 18] {
           line-width: 1.5;

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -824,9 +824,10 @@
       }
     }
 
-    [feature = 'railway_INT-minor-railway'] {
+    [feature = 'railway_INT-minor-railway'],
+    [feature = 'railway_INT-minor-subway'] {
       #bridges {
-        [zoom >= 13] {
+        [zoom >= 14] {
           line-width: 4;
           [zoom >= 15] {
             line-width: 5;
@@ -1102,9 +1103,10 @@
       }
     }
 
-    [feature = 'railway_INT-minor-railway'] {
+    [feature = 'railway_INT-minor-railway'],
+    [feature = 'railway_INT-minor-subway'] {
       #bridges {
-        [zoom >= 13] {
+        [zoom >= 14] {
           line-width: 3;
           [zoom >= 15] {
             line-width: 4;
@@ -2643,6 +2645,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
             light/line-dasharray: 0,8,8,1;
             [zoom >= 18] {
               dark/line-width: 3;
+              dark/line-color: #999;
               light/line-width: 1;
             }
           }
@@ -2665,6 +2668,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
             line-dasharray: 3,3;
             [zoom >= 18] {
               line-width: 2.7;
+              line-color: #999;
             }
           }
           [feature = 'railway_rail'][zoom >= 18] {
@@ -2683,9 +2687,12 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [zoom >= 12] {
         line-color: #ccc;
         [zoom >= 10] { line-color: #aaa; }
+        [zoom >= 12] { line-color: #888; }
         [zoom >= 13] { line-color: #666; }
         line-width: 1;
-        [zoom >= 13] { line-width: 2; }
+        [zoom >= 12] { line-width: 1.25; }
+        [zoom >= 13] { line-width: 1.5; }
+        [zoom >= 14] { line-width: 2; }
         [preserved = 'yes'][zoom >= 13] {
           #roads-fill, #bridges {
             dark/line-width: 3;
@@ -2722,20 +2729,21 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     /* Minor trackage (service=spur/siding/yard) of every railway class except
-    railway=rail shares a single thin, light signature, so that the distinction
+    railway=rail shares a single thin signature, so that the distinction
     between the classes is drawn on the main tracks only. */
-    [feature = 'railway_INT-minor-railway'] {
-      [zoom >= 12] {
-        line-color: #aaa;
+    [feature = 'railway_INT-minor-railway'],
+    [feature = 'railway_INT-minor-subway'] {
+      [zoom >= 14] {
+        line-color: #6E6E6E;
+        /* subway keeps its lighter colour so it stays distinguishable from light_rail;
+           the lighter colour needs a touch more width to stay legible while thin */
+        [feature = 'railway_INT-minor-subway'] {
+          line-color: #999;
+          [zoom < 17] { line-width: 0.75; }
+        }
         line-width: 0.5;
-        [zoom >= 14] {
-          line-width: 0.75;
-        }
-        [zoom >= 15] {
-          line-width: 1;
-        }
         [zoom >= 17] {
-          line-width: 1.25;
+          line-width: 1;
         }
         [zoom >= 18] {
           line-width: 1.5;

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2726,10 +2726,16 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     between the classes is drawn on the main tracks only. */
     [feature = 'railway_INT-minor-railway'] {
       [zoom >= 12] {
-        line-color: #6E6E6E;
+        line-color: #aaa;
         line-width: 0.5;
-        [zoom >= 17] {
+        [zoom >= 14] {
+          line-width: 0.75;
+        }
+        [zoom >= 15] {
           line-width: 1;
+        }
+        [zoom >= 17] {
+          line-width: 1.25;
         }
         [zoom >= 18] {
           line-width: 1.5;

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2659,7 +2659,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           [service = 'INT-minor'] { line-color: #999; }
         }
         line-width: 1;
-        [zoom >= 13] { line-width: 2; }
+        [zoom >= 13] {
+          line-width: 2;
+          [service = 'INT-minor'] { line-width: 1; }
+        }
         [preserved = 'yes'][zoom >= 13] {
           #roads-fill, #bridges {
             dark/line-width: 3;

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -824,9 +824,12 @@
       }
     }
 
-    [feature = 'railway_tram-service'][zoom >= 15],
-    [feature = 'railway_INT-minor-railway'],
-    [feature = 'railway_INT-minor-subway'] {
+    [feature = 'railway_INT-tram-service'][zoom >= 15],
+    [feature = 'railway_INT-light_rail-service'],
+    [feature = 'railway_INT-funicular-service'],
+    [feature = 'railway_INT-narrow_gauge-service'],
+    [feature = 'railway_INT-monorail-service'],
+    [feature = 'railway_INT-subway-service'] {
       #bridges {
         [zoom >= 14] {
           line-width: 4;
@@ -873,7 +876,7 @@
       }
     }
 
-    [feature = 'railway_INT-spur-siding-yard'] {
+    [feature = 'railway_INT-rail-service'] {
       #bridges {
         [zoom >= 13] {
           line-width: 5.7;
@@ -1070,7 +1073,7 @@
       }
     }
 
-    [feature = 'railway_INT-spur-siding-yard'] {
+    [feature = 'railway_INT-rail-service'] {
       #bridges {
         [zoom >= 13] {
           line-width: 4;
@@ -1104,9 +1107,12 @@
       }
     }
 
-    [feature = 'railway_tram-service'][zoom >= 15],
-    [feature = 'railway_INT-minor-railway'],
-    [feature = 'railway_INT-minor-subway'] {
+    [feature = 'railway_INT-tram-service'][zoom >= 15],
+    [feature = 'railway_INT-light_rail-service'],
+    [feature = 'railway_INT-funicular-service'],
+    [feature = 'railway_INT-narrow_gauge-service'],
+    [feature = 'railway_INT-monorail-service'],
+    [feature = 'railway_INT-subway-service'] {
       #bridges {
         [zoom >= 14] {
           line-width: 3;
@@ -2607,7 +2613,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     [feature = 'railway_rail'][zoom >= 8][zoom < 10],
     [feature = 'railway_rail'][preserved != 'yes'][zoom >= 10][zoom < 12],
     [feature = 'railway_rail'][zoom >= 12],
-    [feature = 'railway_INT-spur-siding-yard'][zoom >= 13] {
+    [feature = 'railway_INT-rail-service'][zoom >= 13] {
       [zoom < 13] {
         line-color: #787878;
         line-width: 0.5;
@@ -2640,7 +2646,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
               light/line-width: 2;
             }
           }
-          [feature = 'railway_INT-spur-siding-yard'] {
+          [feature = 'railway_INT-rail-service'] {
             dark/line-width: 2;
             dark/line-color: #aaa;
             light/line-width: 0.8;
@@ -2664,7 +2670,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           line-width: 2.8;
           line-dasharray: 6,4;
           line-clip: false;
-          [feature = 'railway_INT-spur-siding-yard'] {
+          [feature = 'railway_INT-rail-service'] {
             line-color: #aaa;
             line-width: 1.9;
             line-dasharray: 3,3;
@@ -2731,17 +2737,20 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     /* Minor trackage (service=spur/siding/yard) of every railway class except
-    railway=rail shares the thin tram-service signature, so that the distinction
-    between the classes is drawn on the main tracks only. Tram keeps its
-    established z15 start; the other classes begin at z14. */
-    [feature = 'railway_tram-service'][zoom >= 15],
-    [feature = 'railway_INT-minor-railway'],
-    [feature = 'railway_INT-minor-subway'] {
+    railway=rail shares one thin signature, so that the distinction between the
+    classes is drawn on the main tracks only. Tram keeps its established z15
+    start; the other classes begin at z14. */
+    [feature = 'railway_INT-tram-service'][zoom >= 15],
+    [feature = 'railway_INT-light_rail-service'],
+    [feature = 'railway_INT-funicular-service'],
+    [feature = 'railway_INT-narrow_gauge-service'],
+    [feature = 'railway_INT-monorail-service'],
+    [feature = 'railway_INT-subway-service'] {
       [zoom >= 14] {
         line-color: #6E6E6E;
         /* subway keeps its lighter colour so it stays distinguishable from light_rail;
            the lighter colour needs a touch more width to stay legible while thin */
-        [feature = 'railway_INT-minor-subway'] {
+        [feature = 'railway_INT-subway-service'] {
           line-color: #999;
           [zoom < 17] { line-width: 0.75; }
         }


### PR DESCRIPTION
Fixes #5176

Relates to [this](https://github.com/openstreetmap-carto/openstreetmap-carto/issues/1832#issuecomment-1293087851) comment on #1832.

Changes proposed in this pull request:
- When `service=yard` or `service=spur` or `service=siding`, lighten `railway=light_rail`/`railway=funicular`/`railway=narrow_gauge` from `#666` to `#999` (which is the color already used for `railway=subway`)

Test rendering with links to the example places:
As you can see the regular light_rail tracks stay dark, but the yard is deemphasized. These images are a bit zoomed in but if you click the following osm.org links you will see that the yard is currently a dark blob.

[`#15/37.72100/-122.44889`](https://www.openstreetmap.org/#map=15/37.72100/-122.44889)
|Before|After|
|---|---|
|<img width="159" height="128" alt="oK1Y9orz" src="https://github.com/user-attachments/assets/b7b3ca85-f06d-452f-a084-87a412eecd0b" />|<img width="159" height="128" alt="QnOO--2s" src="https://github.com/user-attachments/assets/e6db64df-bc84-47b3-9980-35b0d12ede08" />|
|<img width="319" height="257" alt="BcNnMa83" src="https://github.com/user-attachments/assets/6245e3fc-447b-4fea-b590-407275a90545" />|<img width="319" height="257" alt="K8Fp0j0l" src="https://github.com/user-attachments/assets/566ae7be-f1a9-4020-901f-5dc74874c334" />|
|<img width="637" height="513" alt="NmI21Yje" src="https://github.com/user-attachments/assets/a4cb93c1-f0b1-41d5-a712-f5c0bd97b600" />|<img width="637" height="513" alt="ZDV6kUUu" src="https://github.com/user-attachments/assets/ec3453a2-a2cf-4dd8-b8e9-6caf50b4b1ca" />|
|<img width="1274" height="1026" alt="xFhuJ73S" src="https://github.com/user-attachments/assets/63c26657-b09b-4b01-bc04-581971594298" />|<img width="1274" height="1026" alt="54-kZi2t" src="https://github.com/user-attachments/assets/1a6d5ed6-d46a-4710-bd4c-1da7eb0efa18" />|

[`#15/37.75029/-122.38649`](https://www.openstreetmap.org/#map=15/37.75029/-122.38649)
|Before|After|
|---|---|
|<img width="71" height="92" alt="wdZgFGe_" src="https://github.com/user-attachments/assets/5f7226f5-f794-4eb2-991c-9b2b151c61b2" />|<img width="71" height="92" alt="7HlFSBHH" src="https://github.com/user-attachments/assets/c28cf97a-0264-40fe-983e-f4d65be268e1" />|
|<img width="141" height="184" alt="z8e0VVmG" src="https://github.com/user-attachments/assets/9193e4cd-0002-4d76-b010-1a861d30f93c" />|<img width="141" height="184" alt="Clko4xpY" src="https://github.com/user-attachments/assets/055303e4-c7dc-4c0e-b5d5-a057d91c588b" />|
|<img width="282" height="368" alt="CeNTzqrQ" src="https://github.com/user-attachments/assets/ef85786d-aa11-4f76-ab7f-4e419abb04f5" />|<img width="282" height="368" alt="EwQqt-Zl" src="https://github.com/user-attachments/assets/ff078e32-aa4f-4fc0-b6b9-e12bc5225bf1" />|
|<img width="564" height="736" alt="tg8jgMFH" src="https://github.com/user-attachments/assets/7d3d0a67-3903-426a-9e46-a46431072595" />|<img width="564" height="736" alt="2JMHP4Lk" src="https://github.com/user-attachments/assets/12460115-dea0-44ac-bd09-1f9246969a63" />|


EDIT: I have now added the above table at 1x resolution per imagico's request [here](https://github.com/openstreetmap-carto/openstreetmap-carto/issues/5289#issuecomment-5301899159), sorry about that, the original 2x resolution examples are now collapsed here if anyone is curious:

<details>
<summary>Rendering examples at 2x resolution</summary>

[`#15/37.72100/-122.44889`](https://www.openstreetmap.org/#map=15/37.72100/-122.44889)
|Before|After|
|---|---|
|<img width="319" height="257" alt="ql9kC78T" src="https://github.com/user-attachments/assets/a6539a27-e82e-4915-9044-3406872a85ba" />|<img width="319" height="257" alt="vcAi1CS6" src="https://github.com/user-attachments/assets/9b6e07c3-71af-4ffe-8de0-3409ced496db" />|
|<img width="637" height="513" alt="7OHoTJDn" src="https://github.com/user-attachments/assets/d57107c6-fd5d-45be-8837-00e4d07d54e0" />|<img width="637" height="513" alt="5tLls7ir" src="https://github.com/user-attachments/assets/ebfe0e43-2a1e-4013-a413-d99916b5a178" />|
|<img width="1274" height="1026" alt="uEiiLSkP" src="https://github.com/user-attachments/assets/d3b95fd6-b95d-40e4-9804-97b4b4124d92" />|<img width="1274" height="1026" alt="txl0cifm" src="https://github.com/user-attachments/assets/15e6a2e5-d40d-4277-b35e-ee4b1f6520be" />|
|<img width="2548" height="2052" alt="8VLgFmRZ" src="https://github.com/user-attachments/assets/8a6d5f36-3b3f-4669-a109-8843016c6f41" />|<img width="2548" height="2052" alt="ovvdRkXj" src="https://github.com/user-attachments/assets/f08f26f3-f1d4-4856-96bd-726b42cd0a7e" />|

[`#15/37.75029/-122.38649`](https://www.openstreetmap.org/#map=15/37.75029/-122.38649)
|Before|After|
|---|---|
|<img width="141" height="184" alt="Iasnr6Db" src="https://github.com/user-attachments/assets/6a1c2090-4250-4b3f-bc1b-9e3097fe0348" />|<img width="141" height="184" alt="KvKyQczY" src="https://github.com/user-attachments/assets/f486b382-d140-4b93-ae25-80a1dbf9fdcf" />|
|<img width="282" height="368" alt="zj5QDZP1" src="https://github.com/user-attachments/assets/264593ca-82da-43cf-9b65-00a1a21d1db4" />|<img width="282" height="368" alt="NmVKdu6I" src="https://github.com/user-attachments/assets/1eb5a5dd-5fa5-4de5-ae44-6fcc440936b4" />|
|<img width="564" height="736" alt="GMmyU7E2" src="https://github.com/user-attachments/assets/f8751859-3f05-406b-969a-f521a28f629a" />|<img width="564" height="736" alt="xzEqOfl6" src="https://github.com/user-attachments/assets/aa076fb0-f6ba-4d5e-ac05-53bb2018532d" />|
|<img width="1128" height="1472" alt="2NfDfxiF" src="https://github.com/user-attachments/assets/049565f1-b1ae-4c65-b63f-10f4e9a5deb8" />|<img width="1128" height="1472" alt="HTCe_zdh" src="https://github.com/user-attachments/assets/81cac4bf-4e9d-4114-ac7b-e521b30a7f2c" />|

</details>

"Why not also lighten `railway=subway`?" Answer: because subway is already this light, see an example yard [here](https://www.openstreetmap.org/#map=17/40.866576/-73.915222), which I think already looks fine. This PR changes light_rail to match subway.

"Why combine these three?" Answer: they are already combined, project.mml has `service IN ('spur', 'siding', 'yard')` in several places already. See [here](https://www.openstreetmap.org/#map=18/51.508135/-0.014699) for an area that has a variety. There is also `service=crossover` which maybe should be lightened but I was not sure so I did not include it.