### PR TITLE
Refresh Docker Kosmtik

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble
+FROM ubuntu:26.04
 
 # https://serverfault.com/questions/949991/how-to-install-tzdata-on-a-ubuntu-docker-image
 ARG DEBIAN_FRONTEND=noninteractive
@@ -12,8 +12,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # Kosmtik with plugins, forcing prefix to /usr because Ubuntu sets
 # npm prefix to /usr/local, which breaks the install
 # We install kosmtik not from release channel, but directly from a specific commit on github.
-# 5dbde8db6b5e22073951066b0646a91c10bb81a5 is master's tip as of 2024-11-17.
-RUN npm set prefix /usr && npm install -g --unsafe-perm "git+https://git@github.com/kosmtik/kosmtik.git#5dbde8db6b5e22073951066b0646a91c10bb81a5"
+# Upstream kosmtik/kosmtik is unmaintained, so this uses a fork that bumps
+# @mapnik/mapnik to 4.8.0 (Mapnik 4.3.0, which adds the !unbuffered_bbox! SQL
+# token) and carries assorted rendering/UI fixes on top of upstream master.
+RUN npm set prefix /usr \
+    && npm install -g @mapnik/core-linux-x64@4.3.0 \
+    && npm install -g --unsafe-perm "git+https://git@github.com/leijurv/kosmtik.git#716d585c18c48903ff891bfd342101bc6e9a0c3f"
 
 WORKDIR /usr/lib/node_modules/kosmtik/
 RUN kosmtik plugins --install kosmtik-overpass-layer \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,16 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.db
+    shm_size: 1g
+    command: postgres -c max_connections=200
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
       - PG_WORK_MEM
       - PG_MAINTENANCE_WORK_MEM
+      - PG_MAX_WORKER_PROCESSES
+      - PG_MAX_PARALLEL_WORKERS
+      - PG_MAX_PARALLEL_WORKERS_PER_GATHER
+      - PG_JIT
   import:
     image: openstreetmap-carto-import:v1
     build:

--- a/scripts/tune-postgis.sh
+++ b/scripts/tune-postgis.sh
@@ -1,7 +1,24 @@
 #!/bin/sh
 
+# Tuning for the Docker dev database.
+# We want to optimize for quickly rendering tiles for fast developer feedback.
+# Therefore, we prioritize latency over throughput.
+
 set -e
 export PGUSER="$POSTGRES_USER"
 
+# Count how many CPUs we have.
+NPROC="$(nproc)"
+PER_GATHER="$((NPROC / 4))"
+if [ "$PER_GATHER" -lt 2 ]; then
+	PER_GATHER=2
+fi
+
 psql -c "ALTER SYSTEM SET work_mem='${PG_WORK_MEM:-16MB}';"
 psql -c "ALTER SYSTEM SET maintenance_work_mem='${PG_MAINTENANCE_WORK_MEM:-256MB}';"
+
+psql -c "ALTER SYSTEM SET max_worker_processes='${PG_MAX_WORKER_PROCESSES:-$NPROC}';"
+psql -c "ALTER SYSTEM SET max_parallel_workers='${PG_MAX_PARALLEL_WORKERS:-$NPROC}';"
+psql -c "ALTER SYSTEM SET max_parallel_workers_per_gather='${PG_MAX_PARALLEL_WORKERS_PER_GATHER:-$PER_GATHER}';"
+
+psql -c "ALTER SYSTEM SET jit='${PG_JIT:-off}';"


### PR DESCRIPTION
Fixes #5274

No changes to rendering.

This PR refreshes the Docker dev setup with kosmtik. To see the actual code changes on the kosmtik side, please see https://github.com/leijurv/kosmtik/commits/716d585c18c48903ff891bfd342101bc6e9a0c3f

"How can I try out this PR?" I suggest running: `docker compose build kosmtik && docker compose up -d --no-deps --force-recreate -t0 kosmtik`

The changes across this repo and kosmtik:

- **Mapnik is updated to v4.3.0**. The main reason for the change. This allows `!unbuffered_bbox!`. https://github.com/mapnik/mapnik/pull/4561

- **Native resolution option**. Kosmtik currently forces Retina resolution, also known as 2x resolution, where tiles are 512x512. I added an option to toggle this off (back down to 256x256).

<details><summary>Demo of this (click to expand)</summary>

https://github.com/user-attachments/assets/cd940635-632e-474f-8264-6c7f86447d2c

</details>

- **Buffer size fix**. Kosmtik currently has a bug with buffer size. See this PR: https://github.com/kosmtik/kosmtik/pull/364 I made it configurable.

<details><summary>Demo of this (click to expand)</summary>

https://github.com/user-attachments/assets/1d82a9db-44e0-4165-91c0-a78acbb7dd0f

</details>

- **Misc small fixes overall**. Metatile boundaries were very laggy when panning. Mobile view looked strange. The metatile cache would rarely crash for no good reason. Opening the "Reference" tab would crash the kosmtik server.

<details><summary>Demo of this (click to expand)</summary>

Before. The map and the controls are too small.
<img width="200" alt="Screenshot_20260816-000058" src="https://github.com/user-attachments/assets/feaf6db4-52f1-48cd-886c-ff9b2326cf23" />

After.
<img width="200" alt="Screenshot_20260816-000448" src="https://github.com/user-attachments/assets/9b19d00d-b413-4e80-890c-c8151011f7d0" />

</details>

- **Cancel rendering a tile if it can't be seen anymore**. Imagine I am viewing London at Z8, I then zoom in to Z15. Currently kosmtik will fully render all those zoom levels Z9 Z10 Z11 Z12 Z13 Z14 Z15. This takes **3 minutes 24 seconds** for me before I start to see Z15 tiles. I have changed it so that mapnik is killed if the tile is no longer wanted (not on the screen anymore). Now, when I zoom from Z8 to Z15, it takes **six seconds** for me before I start to see Z15 tiles. Screen recordings below. This also helps a lot when panning around. Generally navigating the map becomes much more pleasant.

<details><summary>Screen recordings (click to expand)</summary>

Before. As you can see, it takes several minutes of nothing happening before I see the tiles. Then, when I zoom back out, we realize the problem: it's instantly showing me every zoom level in between, demonstrating how all that was rendered before showing me Z15.

https://github.com/user-attachments/assets/85f58092-7297-4928-b3f0-bd0c388a96f7

After. Z15 renders very quickly. When we zoom back out, the intermediary zoom levels are **not** done yet. Also, the logs are more clear about what is happening (compare to in the above recording, there is no indication what is happening because the canceled tiles are printing no logs at all - VERY confusing!)

https://github.com/user-attachments/assets/50a28f35-7242-400a-b54e-73c253dd166c

</details>

- **Overall performance improvements**. Mostly this is tuning postgres, and enabling the option to run multiple postgres queries at once. Currently kosmtik runs the layers one at a time, querying postgres, drawing its results, repeat. But there is an easy option you can turn on, to run several queries at once. Mapnik does still paint the results one layer at a time, so this only speeds up the queries via overlapping. I think this is reasonable because when developing OSM Carto you want to see the results immediately, so, latency matters the most, and the throughput is not important (it's not a real production tileserver). These changes also contribute to the above screen recording speedup.