### PR TITLE
Hide admin boundary segments with both endpoints on the ±180° antimeridian

### DIFF
--- a/functions.sql
+++ b/functions.sql
@@ -152,3 +152,45 @@ BEGIN
   RETURN listtext;
 END;
 $$;
+
+/* Remove antimeridian closure segments from a boundary linestring.
+
+   Boundary relations that cross the antimeridian are closed with artificial
+   member ways (tagged closure_segment=yes) running along lon +/-180. Those ways
+   carry no boundary tags of their own, and line_merge() folds them into the
+   relation geometry, so the tag is not present on the rendered row and cannot be
+   filtered directly. Instead drop every segment with BOTH endpoints on the
+   antimeridian; a segment with only one endpoint there is real boundary linework
+   meeting it, and is kept.
+
+   The 0.5m tolerance is deliberate. OSM stores coordinates as integers at 1e-7
+   degrees, so one unit in the last place is 1.11cm in Web Mercator, and nodes
+   intended to sit at 180 are frequently stored as 179.9999999. Across the
+   antimeridian data tested no vertex falls between 2cm and 1m of +/-180, while
+   the nearest genuine boundary node is 13m out, so 0.5m separates them cleanly.
+
+   The guard uses the && operator rather than the more obvious ST_XMax/ST_XMin
+   because ST_XMax(geometry) casts to box3d, which reads every vertex, and
+   the caller evaluates this expression once per output plus once per NULL/empty
+   check. On a dense admin tile that measured ~3x the cost of the whole query,
+   while && compares only the cached bounding box.
+
+   Returns NULL when every segment was removed - ST_Collect over zero rows is
+   NULL, so the result is never an empty geometry - and callers only need to
+   discard NULL. */
+CREATE OR REPLACE FUNCTION carto_filter_antimeridian(way geometry)
+  RETURNS geometry
+  LANGUAGE SQL
+  IMMUTABLE PARALLEL SAFE
+AS $$
+SELECT
+	CASE
+		WHEN way && ST_MakeEnvelope(20037507.84, -20037509, 20037509, 20037509, 3857)
+		  OR way && ST_MakeEnvelope(-20037509, -20037509, -20037507.84, 20037509, 3857) THEN
+			(SELECT ST_LineMerge(ST_Collect(s.geom))
+				FROM ST_DumpSegments(way) s
+				WHERE NOT (abs(abs(ST_X(ST_StartPoint(s.geom))) - 20037508.342789244) < 0.5
+					AND abs(abs(ST_X(ST_EndPoint(s.geom))) - 20037508.342789244) < 0.5))
+		ELSE way
+	END
+$$;

--- a/project.mml
+++ b/project.mml
@@ -1092,8 +1092,7 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT way, admin_level FROM (
-          SELECT
+        (SELECT
             carto_filter_antimeridian(way) AS way,
             admin_level
           FROM planet_osm_roads
@@ -1101,9 +1100,7 @@ Layer:
             AND admin_level IN ('0', '1', '2', '3', '4')
             AND osm_id < 0
             AND way && !bbox!
-        ) q
-        WHERE way IS NOT NULL
-        ORDER BY admin_level DESC
+          ORDER BY admin_level DESC
         ) AS admin_low_zoom
     properties:
       minzoom: 4
@@ -1114,8 +1111,7 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT way, admin_level FROM (
-          SELECT
+        (SELECT
             carto_filter_antimeridian(way) AS way,
             admin_level
           FROM planet_osm_roads
@@ -1123,9 +1119,7 @@ Layer:
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')
             AND osm_id < 0
             AND way && !bbox!
-        ) q
-        WHERE way IS NOT NULL
-        ORDER BY admin_level DESC
+          ORDER BY admin_level DESC
         ) AS admin_mid_zoom
     properties:
       minzoom: 8
@@ -1136,8 +1130,7 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT way, admin_level FROM (
-          SELECT
+        (SELECT
             carto_filter_antimeridian(way) AS way,
             admin_level
           FROM planet_osm_roads
@@ -1145,9 +1138,7 @@ Layer:
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
             AND osm_id < 0
             AND way && !bbox!
-        ) q
-        WHERE way IS NOT NULL
-        ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
+          ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
         ) AS admin_high_zoom
     properties:
       minzoom: 13

--- a/project.mml
+++ b/project.mml
@@ -1094,13 +1094,7 @@ Layer:
       table: |-
         (SELECT way, admin_level FROM (
           SELECT
-            CASE WHEN ST_XMax(way) > 20037507.84 OR ST_XMin(way) < -20037507.84
-              THEN (SELECT ST_LineMerge(ST_Collect(s.geom))
-                      FROM ST_DumpSegments(way) s
-                     WHERE NOT (abs(abs(ST_X(ST_StartPoint(s.geom))) - 20037508.342789244) < 0.5
-                            AND abs(abs(ST_X(ST_EndPoint(s.geom)))   - 20037508.342789244) < 0.5))
-              ELSE way
-            END AS way,
+            carto_filter_antimeridian(way) AS way,
             admin_level
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
@@ -1108,7 +1102,7 @@ Layer:
             AND osm_id < 0
             AND way && !bbox!
         ) q
-        WHERE way IS NOT NULL AND NOT ST_IsEmpty(way)
+        WHERE way IS NOT NULL
         ORDER BY admin_level DESC
         ) AS admin_low_zoom
     properties:
@@ -1122,13 +1116,7 @@ Layer:
       table: |-
         (SELECT way, admin_level FROM (
           SELECT
-            CASE WHEN ST_XMax(way) > 20037507.84 OR ST_XMin(way) < -20037507.84
-              THEN (SELECT ST_LineMerge(ST_Collect(s.geom))
-                      FROM ST_DumpSegments(way) s
-                     WHERE NOT (abs(abs(ST_X(ST_StartPoint(s.geom))) - 20037508.342789244) < 0.5
-                            AND abs(abs(ST_X(ST_EndPoint(s.geom)))   - 20037508.342789244) < 0.5))
-              ELSE way
-            END AS way,
+            carto_filter_antimeridian(way) AS way,
             admin_level
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
@@ -1136,7 +1124,7 @@ Layer:
             AND osm_id < 0
             AND way && !bbox!
         ) q
-        WHERE way IS NOT NULL AND NOT ST_IsEmpty(way)
+        WHERE way IS NOT NULL
         ORDER BY admin_level DESC
         ) AS admin_mid_zoom
     properties:
@@ -1150,13 +1138,7 @@ Layer:
       table: |-
         (SELECT way, admin_level FROM (
           SELECT
-            CASE WHEN ST_XMax(way) > 20037507.84 OR ST_XMin(way) < -20037507.84
-              THEN (SELECT ST_LineMerge(ST_Collect(s.geom))
-                      FROM ST_DumpSegments(way) s
-                     WHERE NOT (abs(abs(ST_X(ST_StartPoint(s.geom))) - 20037508.342789244) < 0.5
-                            AND abs(abs(ST_X(ST_EndPoint(s.geom)))   - 20037508.342789244) < 0.5))
-              ELSE way
-            END AS way,
+            carto_filter_antimeridian(way) AS way,
             admin_level
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
@@ -1164,7 +1146,7 @@ Layer:
             AND osm_id < 0
             AND way && !bbox!
         ) q
-        WHERE way IS NOT NULL AND NOT ST_IsEmpty(way)
+        WHERE way IS NOT NULL
         ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
         ) AS admin_high_zoom
     properties:

--- a/project.mml
+++ b/project.mml
@@ -1092,14 +1092,24 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT
-            way,
+        (SELECT way, admin_level FROM (
+          SELECT
+            CASE WHEN ST_XMax(way) > 20037507.84 OR ST_XMin(way) < -20037507.84
+              THEN (SELECT ST_LineMerge(ST_Collect(s.geom))
+                      FROM ST_DumpSegments(way) s
+                     WHERE NOT (abs(abs(ST_X(ST_StartPoint(s.geom))) - 20037508.342789244) < 0.5
+                            AND abs(abs(ST_X(ST_EndPoint(s.geom)))   - 20037508.342789244) < 0.5))
+              ELSE way
+            END AS way,
             admin_level
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4')
             AND osm_id < 0
-          ORDER BY admin_level DESC
+            AND way && !bbox!
+        ) q
+        WHERE way IS NOT NULL AND NOT ST_IsEmpty(way)
+        ORDER BY admin_level DESC
         ) AS admin_low_zoom
     properties:
       minzoom: 4
@@ -1110,14 +1120,24 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT
-            way,
+        (SELECT way, admin_level FROM (
+          SELECT
+            CASE WHEN ST_XMax(way) > 20037507.84 OR ST_XMin(way) < -20037507.84
+              THEN (SELECT ST_LineMerge(ST_Collect(s.geom))
+                      FROM ST_DumpSegments(way) s
+                     WHERE NOT (abs(abs(ST_X(ST_StartPoint(s.geom))) - 20037508.342789244) < 0.5
+                            AND abs(abs(ST_X(ST_EndPoint(s.geom)))   - 20037508.342789244) < 0.5))
+              ELSE way
+            END AS way,
             admin_level
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')
             AND osm_id < 0
-          ORDER BY admin_level DESC
+            AND way && !bbox!
+        ) q
+        WHERE way IS NOT NULL AND NOT ST_IsEmpty(way)
+        ORDER BY admin_level DESC
         ) AS admin_mid_zoom
     properties:
       minzoom: 8
@@ -1128,14 +1148,24 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT
-            way,
+        (SELECT way, admin_level FROM (
+          SELECT
+            CASE WHEN ST_XMax(way) > 20037507.84 OR ST_XMin(way) < -20037507.84
+              THEN (SELECT ST_LineMerge(ST_Collect(s.geom))
+                      FROM ST_DumpSegments(way) s
+                     WHERE NOT (abs(abs(ST_X(ST_StartPoint(s.geom))) - 20037508.342789244) < 0.5
+                            AND abs(abs(ST_X(ST_EndPoint(s.geom)))   - 20037508.342789244) < 0.5))
+              ELSE way
+            END AS way,
             admin_level
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
             AND osm_id < 0
-          ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
+            AND way && !bbox!
+        ) q
+        WHERE way IS NOT NULL AND NOT ST_IsEmpty(way)
+        ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
         ) AS admin_high_zoom
     properties:
       minzoom: 13


### PR DESCRIPTION
Fixes #3504

Changes proposed in this pull request:
- <b>Hide individual segments of an admin boundary linestring way if its `ST_StartPoint` and `ST_EndPoint` are both within 0.5 (mercator) meters of the antimeridian.</b>


Test rendering with links to the example places:

[`#5/67.991/-182.681`](https://www.openstreetmap.org/#map=5/67.99/177.32)
<img width="124" height="454" alt="Image" src="https://github.com/user-attachments/assets/d6806612-6855-4759-926a-17595d0efaca" /> <img width="124" height="454" alt="Image" src="https://github.com/user-attachments/assets/25d02fc9-4223-4b32-b086-6c48d8ca17e9" />

<br>

[`#7/-17.696/-179.517`](https://www.openstreetmap.org/#map=7/-17.696/-179.517)
<img width="300" alt="Image" src="https://github.com/user-attachments/assets/4e646495-f93a-4e36-89bf-07d6a6d799a0" /> <img width="300" alt="Image" src="https://github.com/user-attachments/assets/b005fb01-e749-4620-82f7-9e77e7052501" />

For more context see [this comment](https://github.com/openstreetmap-carto/openstreetmap-carto/issues/3504#issuecomment-5401977453). From then until this PR, I just rearranged it a bit and tested the performance. Turns out `&&` is by far the fastest way to test if a way touches the antimeridian, the prior method (`ST_XMin` & `ST_XMax`) caused Postgres to test every individual vertex of the linestring, whereas `&&` is able to use the cached bbox. Also, I had to add `AND way && !bbox!` because the `way` is now processed by the function, so mapnik's `&& !bbox!` was insufficient to get index acceleration.