### PR TITLE
Typo fix to reduce rows selected

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1040,8 +1040,8 @@ Layer:
           FROM planet_osm_line
           WHERE aerialway IS NOT NULL
             OR (man_made = 'pipeline'
-                AND tags-> 'location' IN ('overground', 'overhead', 'surface', 'outdoor')
-                OR bridge IN ('yes', 'aqueduct', 'cantilever', 'covered', 'trestle', 'viaduct'))
+                AND (tags-> 'location' IN ('overground', 'overhead', 'surface', 'outdoor')
+                     OR bridge IN ('yes', 'aqueduct', 'cantilever', 'covered', 'trestle', 'viaduct')))
             OR (man_made = 'goods_conveyor'
                 AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                 AND (tunnel NOT IN ('yes') OR tunnel IS NULL))
@@ -2146,8 +2146,8 @@ Layer:
           FROM planet_osm_line
           WHERE ((man_made IN ('pier', 'breakwater', 'groyne', 'embankment')
               OR (man_made = 'pipeline'
-                 AND tags-> 'location' IN ('overground', 'overhead', 'surface', 'outdoor')
-                 OR bridge IN ('yes', 'aqueduct', 'cantilever', 'covered', 'trestle', 'viaduct'))
+                 AND (tags-> 'location' IN ('overground', 'overhead', 'surface', 'outdoor')
+                      OR bridge IN ('yes', 'aqueduct', 'cantilever', 'covered', 'trestle', 'viaduct')))
               OR tags @> 'attraction=>water_slide'
               OR aerialway IN ('cable_car', 'gondola', 'mixed_lift', 'goods', 'chair_lift', 'drag_lift', 't-bar', 'j-bar', 'platter', 'rope_tow', 'zip_line')
               OR leisure IN ('slipway', 'track')


### PR DESCRIPTION
No rendering changes.

Changes proposed in this pull request:
- Two of the SQL queries have a tiny typo relating to parentheses and operator precedence that causes a significant number of unintended rows to be selected.

Original commit: https://github.com/openstreetmap-carto/openstreetmap-carto/commit/b9f560c2b5882ec40f72aed06c4a4df3ea32cbcd

The intent here was to "select pipelines with bridge" (quoted from the commit msg).

|Intent|Actually written|
|---|---|
|`pipeline` AND (`location` OR `bridge`)|(`pipeline` AND `location`) OR `bridge`|

So it is unintentionally pulling in every bridge.

The extra rows caused by this typo don't change any rendering - it just loads a bunch of rows into mapnik that won't match any symbolizer. Specifically, for `aerialways` 97% of the matched rows are discarded and for `text-line` 82% across my db. So this is just a small performance hit. After this PR, the rows that match no symbolizer decrease to 1.8% for `aerialways` and 2.5% for `text-line`. And those other gaps are perhaps preexisting bug(s) for example ways that are tagged `natural=cliff` and `leisure=climbing` are int'd as `leisure_climbing` rather than `natural_cliff` so go unrendered, which is possibly a bug.

In theory, you could imagine strange tag combinations that would be affected by this change, but I don't have any in my database. For example: a way that is tagged, `man_made=goods_conveyor` and `bridge=*` and `location=underground`. If such a way exists I think the rendering is already unintended. So across dense areas like Tokyo, the Netherlands, California, etc, the output PNGs are totally unaffected by this PR.

This PR is a big performance improvement to the affected layers if you use latest released mapnik. For example, Z12 NYC `aerialways` goes from 54ms to <1ms. Separately I also optimized this case (many rows that match 0 symbolizers) in this PR https://github.com/mapnik/mapnik/pull/4573 which was (surprisingly) merged just yesterday, so if you have mapnik built from source, this PR becomes less of a win. (4ms -> 0.8ms, rather than 54ms -> 0.9ms).