### PR TITLE
Put sort keys before geometry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,10 @@ PostgreSQL sorts the results:
 * Put the geometry (`way`) at the end of the `SELECT` list, including in queries without `ORDER BY`.
 * Select expressions used for sorting as named columns, and use those names in `ORDER BY`.
 
+Among the sort columns, prefer placing non-null, fixed-width columns before nullable
+or variable-width columns. Their order in `SELECT` need not match their order in
+`ORDER BY`; leave the intended sorting precedence unchanged.
+
 This lets PostgreSQL access sort keys without repeatedly stepping over the geometry.
 Mapnik selects only the columns needed by the style, so columns added solely for
 sorting are not sent to Mapnik. See [#5297](https://github.com/openstreetmap-carto/openstreetmap-carto/pull/5297)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,7 @@ instead of
 ```
 
 ## SQL style guidelines
+
 Because SQL within YAML will not generally be syntax highlighted, indentation and caps are particularly important.
 
 * SQL keywords in caps, as in PostgreSQL documentation
@@ -174,6 +175,18 @@ Because SQL within YAML will not generally be syntax highlighted, indentation an
 * When extracting tags from hstore, use `tags->'foo'`, not `tags -> 'foo'`, and only add parentheses if needed for order of operations
 * Hstore queries tested for NULL should be enclosed in parentheses, e.g. `(tags->'foo') IS NULL`.
 * To check if a tag is in the tags hstore, use `tags @> 'foo=>bar'`, relying on automatic conversion from `text` to `hstore`.
+
+Use a consistent column order in layer queries to avoid unnecessary work when
+PostgreSQL sorts the results:
+
+* Put columns used by `ORDER BY` at the beginning of the `SELECT` list.
+* Put the geometry (`way`) at the end of the `SELECT` list, including in queries without `ORDER BY`.
+* Select expressions used for sorting as named columns, and use those names in `ORDER BY`.
+
+This lets PostgreSQL access sort keys without repeatedly stepping over the geometry.
+Mapnik selects only the columns needed by the style, so columns added solely for
+sorting are not sent to Mapnik. See [#5297](https://github.com/openstreetmap-carto/openstreetmap-carto/pull/5297)
+for the explanation and measurements.
 
 ## Map icon guidelines
 

--- a/project.mml
+++ b/project.mml
@@ -830,7 +830,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            z_order,
+            osm_id,
             COALESCE(
               ('highway_' || (CASE WHEN highway IN ('motorway_link', 'trunk_link', 'primary_link', 'secondary_link', 'tertiary_link')
                                      THEN substr(highway, 0, length(highway)-4) ELSE highway end)),
@@ -838,7 +839,8 @@ Layer:
             ) AS feature,
             CASE WHEN tunnel IN ('yes', 'building_passage', 'avalanche_protector') OR covered = 'yes' THEN 'yes' ELSE 'no' END AS int_tunnel,
             CASE WHEN highway IN ('motorway_link', 'trunk_link', 'primary_link', 'secondary_link', 'tertiary_link') THEN 'yes' ELSE 'no' END AS link,
-            carto_highway_int_surface(surface) AS int_surface
+            carto_highway_int_surface(surface) AS int_surface,
+            way
           FROM planet_osm_roads
           WHERE highway IS NOT NULL
             OR (railway IN ('rail', 'light_rail', 'funicular', 'narrow_gauge')

--- a/project.mml
+++ b/project.mml
@@ -424,17 +424,19 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            COALESCE(layer,0) AS layernotnull, -- sort keys first, geometry last: see roads_sql
+            way_area,
             building,
             amenity,
             aeroway,
             aerialway,
-            tags->'public_transport' as public_transport
+            tags->'public_transport' as public_transport,
+            way
           FROM planet_osm_polygon
           WHERE building IS NOT NULL
             AND building != 'no'
             AND way_area > 1*!pixel_width!::real*!pixel_height!::real
-          ORDER BY COALESCE(layer,0), way_area DESC
+          ORDER BY layernotnull, way_area DESC
         ) AS buildings
     properties:
       minzoom: 14
@@ -453,7 +455,13 @@ Layer:
       # - Return two linestrings for ways which are both a road and railway
       table: |-
         (SELECT
-            way,
+            COALESCE(layer,0) AS layernotnull,
+            z_order,
+            CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END AS sort_rail,
+            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END AS sort_service,
+            CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END AS sort_access,
+            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END AS sort_surface,
+            osm_id,
             CASE WHEN link = 'yes' THEN substr(feature, 0, length(feature)-4) ELSE feature END AS feature,
             tracktype,
             int_surface,
@@ -462,7 +470,7 @@ Layer:
             service,
             link,
             preserved,
-            COALESCE(layer,0) AS layernotnull
+            way
           FROM ( -- subselect that contains both roads and rail
             SELECT
                 way,
@@ -510,14 +518,11 @@ Layer:
               WHERE (tunnel IN ('yes', 'building_passage', 'avalanche_protector') OR covered = 'yes')
                 AND (railway NOT IN ('platform') AND railway IS NOT NULL) -- end of rail select
             ) AS features
+          -- The sort keys are the first, fixed-width columns and the geometry the last one on
+          -- purpose: comparing rows in the sort otherwise has to step over the geometry to reach
+          -- each key, which made the sort the largest cost of this query.
           ORDER BY
-            layernotnull,
-            z_order,
-            CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
-            CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
-            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
-            osm_id
+            layernotnull, z_order, sort_rail, sort_service, sort_access, sort_surface, osm_id
         ) AS tunnels
     properties:
       cache-features: true
@@ -695,7 +700,13 @@ Layer:
       # - Return two linestrings for ways which are both a road and railway
       table: &roads_sql |-
         (SELECT
-            way,
+            COALESCE(layer,0) AS layernotnull,
+            z_order,
+            CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END AS sort_rail,
+            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END AS sort_service,
+            CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END AS sort_access,
+            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END AS sort_surface,
+            osm_id,
             CASE WHEN link = 'yes' THEN substr(feature, 0, length(feature)-4) ELSE feature END AS feature,
             tracktype,
             int_surface,
@@ -704,7 +715,7 @@ Layer:
             service,
             link,
             preserved,
-            COALESCE(layer,0) AS layernotnull
+            way
           FROM ( -- subselect that contains both roads and rail/aero
             SELECT
                 way,
@@ -757,14 +768,11 @@ Layer:
                 AND (railway NOT IN ('platform') OR (tags->'location' NOT IN ('underground')) OR (tags->'location') IS NULL)
                 AND railway IS NOT NULL -- end of rail select
             ) AS features
+          -- The sort keys are the first, fixed-width columns and the geometry the last one on
+          -- purpose: comparing rows in the sort otherwise has to step over the geometry to reach
+          -- each key, which made the sort the largest cost of this query.
           ORDER BY
-            layernotnull,
-            z_order,
-            CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
-            CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
-            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
-            osm_id
+            layernotnull, z_order, sort_rail, sort_service, sort_access, sort_surface, osm_id
         ) AS roads_sql
     properties:
       cache-features: true
@@ -859,7 +867,13 @@ Layer:
       # - Return two linestrings for ways which are both a road and railway
       table: |-
         (SELECT
-            way,
+            COALESCE(layer,0) AS layernotnull,
+            z_order,
+            CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END AS sort_rail,
+            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END AS sort_service,
+            CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END AS sort_access,
+            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END AS sort_surface,
+            osm_id,
             CASE WHEN link = 'yes' THEN substr(feature, 0, length(feature)-4) ELSE feature END AS feature,
             tracktype,
             int_surface,
@@ -870,7 +884,7 @@ Layer:
             preserved,
             int_intermittent,
             'bridge' AS int_bridge_tunnel,
-            COALESCE(layer,0) AS layernotnull
+            way
           FROM ( -- subselect that contains both roads and rail/aero
             SELECT
                 way,
@@ -942,14 +956,11 @@ Layer:
                 AND (bridge IN ('yes', 'aqueduct') OR (waterway = 'fish_pass'))
                 AND (tunnel IS NULL OR tunnel NOT IN ('yes', 'culvert', 'flooded'))
             ) AS features
+          -- The sort keys are the first, fixed-width columns and the geometry the last one on
+          -- purpose: comparing rows in the sort otherwise has to step over the geometry to reach
+          -- each key, which made the sort the largest cost of this query.
           ORDER BY
-            layernotnull,
-            z_order,
-            CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
-            CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
-            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
-            osm_id
+            layernotnull, z_order, sort_rail, sort_service, sort_access, sort_surface, osm_id
         ) AS bridges
     properties:
       cache-features: true
@@ -1965,15 +1976,19 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            z_order, -- sort keys first, geometry last: see roads_sql
+            COALESCE(layer, 0) AS layernotnull,
+            length(name) AS name_length,
+            name,
+            l.osm_id,
             CASE WHEN substr(highway, length(highway)-4, 5) = '_link' THEN substr(highway, 0, length(highway)-4) ELSE highway END,
             CASE WHEN (tunnel IN ('yes', 'building_passage', 'avalanche_protector') OR covered = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,
             construction,
-            name,
             CASE
               WHEN oneway IN ('yes', '-1') THEN oneway
               WHEN junction IN ('roundabout') AND (oneway IS NULL OR NOT oneway IN ('no', 'reversible')) THEN 'yes'
-            END AS oneway
+            END AS oneway,
+            way
           FROM planet_osm_line l
           WHERE highway IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary',
                             'tertiary_link', 'residential', 'unclassified', 'road', 'service', 'pedestrian', 'raceway', 'living_street', 'construction', 'bus_guideway')
@@ -1982,10 +1997,10 @@ Layer:
               OR junction IN ('roundabout'))
           ORDER BY
             z_order DESC, -- put important roads first
-            COALESCE(layer, 0), -- put top layered roads first
-            length(name) DESC, -- Try to fit big labels in first
+            layernotnull, -- put top layered roads first
+            name_length DESC, -- Try to fit big labels in first
             name DESC, -- Force a consistent ordering between differently named streets
-            l.osm_id DESC -- Force an ordering for streets of the same name, e.g. dualized roads
+            osm_id DESC -- Force an ordering for streets of the same name, e.g. dualized roads
         ) AS roads_text_name
     properties:
       cache-features: true

--- a/project.mml
+++ b/project.mml
@@ -1979,8 +1979,8 @@ Layer:
             z_order, -- sort keys first, geometry last: see roads_sql
             COALESCE(layer, 0) AS layernotnull,
             length(name) AS name_length,
-            name,
             l.osm_id,
+            name,
             CASE WHEN substr(highway, length(highway)-4, 5) = '_link' THEN substr(highway, 0, length(highway)-4) ELSE highway END,
             CASE WHEN (tunnel IN ('yes', 'building_passage', 'avalanche_protector') OR covered = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,
             construction,

--- a/project.mml
+++ b/project.mml
@@ -1665,6 +1665,8 @@ Layer:
             *
           FROM
           (SELECT -- This subselect allows filtering on the feature column
+              osm_id,
+              COALESCE(way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0), 0) AS way_pixels,
               CASE
                 WHEN "natural" IN ('peak', 'volcano', 'saddle')
                      OR tags->'mountain_pass' = 'yes' THEN
@@ -1676,8 +1678,6 @@ Layer:
                     WHEN tags->'height' ~ '^\d{1,3}(\.\d+)?( m)?$' THEN (SUBSTRING(tags->'height', '^(\d{1,3}(\.\d+)?)( m)?$'))::NUMERIC
                   END
               END AS score,
-              COALESCE(way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0), 0) AS way_pixels,
-              osm_id,
               CASE
                 WHEN amenity = 'parcel_locker'
                 THEN CONCAT_WS(E'\n', COALESCE(tags->'brand', tags->'operator', name), ref)

--- a/project.mml
+++ b/project.mml
@@ -63,16 +63,18 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, way_pixels,
-            COALESCE(wetland, landuse, "natural") AS feature
+            way_area,
+            COALESCE(wetland, landuse, "natural") AS feature,
+            way_pixels,
+            way
           FROM (SELECT
-              way,
               ('landuse_' || (CASE WHEN landuse IN ('forest', 'farmland', 'residential', 'commercial', 'retail', 'industrial',
                                                     'meadow', 'grass', 'village_green', 'vineyard', 'orchard') THEN landuse END)) AS landuse,
               ('natural_' || (CASE WHEN "natural" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock', 'heath', 'grassland', 'scrub') THEN "natural" END)) AS "natural",
               ('wetland_' || (CASE WHEN "natural" IN ('wetland', 'mud') THEN (CASE WHEN "natural" IN ('mud') THEN "natural" ELSE tags->'wetland' END) END)) AS wetland,
               way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
-              way_area
+              way_area,
+              way
             FROM planet_osm_polygon
             WHERE (landuse IN ('forest', 'farmland', 'residential', 'commercial', 'retail', 'industrial', 'meadow', 'grass', 'village_green', 'vineyard', 'orchard')
               OR "natural" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock', 'heath', 'grassland', 'scrub'))
@@ -92,10 +94,12 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, religion, way_pixels,
-            COALESCE(aeroway, golf, amenity, wetland, power, landuse, leisure, man_made, "natural", shop, tourism, highway, railway) AS feature
+            way_area,
+            COALESCE(aeroway, golf, amenity, wetland, power, landuse, leisure, man_made, "natural", shop, tourism, highway, railway) AS feature,
+            religion,
+            way_pixels,
+            way
           FROM (SELECT
-              way,
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway END)) AS aeroway,
               ('golf_' || (CASE WHEN (tags->'golf') IN ('rough', 'fairway', 'driving_range', 'water_hazard', 'green', 'bunker', 'tee') THEN tags->'golf' ELSE NULL END)) AS golf,
               ('amenity_' || (CASE WHEN amenity IN ('bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'taxi',
@@ -120,7 +124,8 @@ Layer:
               ('railway_' || (CASE WHEN railway = 'station' THEN railway END)) AS railway,
               CASE WHEN religion IN ('christian', 'jewish', 'muslim') THEN religion ELSE 'INT-generic'::text END AS religion,
               way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
-              way_area
+              way_area,
+              way
             FROM planet_osm_polygon
             WHERE (landuse IS NOT NULL
               OR leisure IS NOT NULL
@@ -175,10 +180,10 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
-              THEN 'yes' ELSE 'no' END AS int_intermittent
+              THEN 'yes' ELSE 'no' END AS int_intermittent,
+            way
           FROM planet_osm_line
           WHERE waterway = 'river'
         ) AS water_lines_low_zoom
@@ -192,18 +197,23 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            *
+            layernotnull,
+            CASE WHEN int_bridge_tunnel = 'tunnel' THEN 1 ELSE 0 END AS sort_tunnel,
+            feature,
+            int_intermittent,
+            int_bridge_tunnel,
+            way
           FROM
           (SELECT -- This subselect allows sorting / filtering on the int_bridge_tunnel column
-              way,
-              'waterway_' || waterway AS feature, 
+              'waterway_' || waterway AS feature,
               CASE WHEN tags->'intermittent' IN ('yes')
                 OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
                 THEN 'yes' ELSE 'no' END AS int_intermittent,
               CASE WHEN tunnel IN ('yes', 'culvert') 
                 OR waterway = 'canal' AND tunnel = 'flooded'
                 THEN 'tunnel' ELSE 'no' END AS int_bridge_tunnel,
-              COALESCE(layer,0) AS layernotnull
+              COALESCE(layer,0) AS layernotnull,
+              way
             FROM planet_osm_line
             WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
               AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
@@ -211,7 +221,7 @@ Layer:
           WHERE (feature != 'waterway_fish_pass') OR (int_bridge_tunnel = 'tunnel') -- only render fish_pass in tunnels with this select
           ORDER BY
             layernotnull,
-            CASE WHEN int_bridge_tunnel = 'tunnel' THEN 1 ELSE 0 END  -- render tunnels after normal waterways (bridges are in later layer)
+            sort_tunnel  -- render tunnels after normal waterways (bridges are in later layer)
         ) AS water_lines
     properties:
       cache-features: true
@@ -223,7 +233,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            COALESCE(layer,0) AS layernotnull,
+            way_area,
             "natural",
             waterway,
             landuse,
@@ -231,7 +242,8 @@ Layer:
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               OR tags->'basin' IN ('detention', 'infiltration')
-              THEN 'yes' ELSE 'no' END AS int_intermittent
+              THEN 'yes' ELSE 'no' END AS int_intermittent,
+            way
           FROM planet_osm_polygon
           WHERE
             (waterway IN ('dock', 'riverbank')
@@ -239,7 +251,7 @@ Layer:
               OR "natural" IN ('water', 'glacier'))
             AND building IS NULL
             AND way_area > 1*!pixel_width!::real*!pixel_height!::real
-          ORDER BY COALESCE(layer,0), way_area DESC
+          ORDER BY layernotnull, way_area DESC
         ) AS water_areas
     properties:
       cache-features: true
@@ -275,7 +287,9 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, surface,
+            COALESCE(layer,0) AS layernotnull,
+            way_area,
+            surface,
             COALESCE(CASE WHEN landuse = 'forest' THEN 'wood' END, "natural") AS "natural",
             CASE WHEN "natural" = 'mud'
                 THEN "natural"
@@ -288,12 +302,13 @@ Layer:
               END AS int_wetland,
             landuse,
             tags->'leaf_type' AS leaf_type,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
+            way
           FROM planet_osm_polygon
           WHERE ("natural" IN ('mud', 'wetland', 'wood', 'beach', 'shoal', 'reef', 'scrub') OR landuse IN ('forest', 'salt_pond'))
             AND building IS NULL
             AND way_area > 1*!pixel_width!::real*!pixel_height!::real
-          ORDER BY COALESCE(layer,0), way_area DESC
+          ORDER BY layernotnull, way_area DESC
         ) AS landcover_area_symbols
     properties:
       cache-features: true
@@ -305,8 +320,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            ice_edge
+            ice_edge,
+            way
           FROM icesheet_outlines
         ) AS icesheet_outlines
     properties:
@@ -331,8 +346,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            waterway
+            waterway,
+            way
           FROM planet_osm_polygon
           WHERE waterway IN ('dam')
         ) AS water_barriers_poly
@@ -345,8 +360,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            waterway
+            waterway,
+            way
           FROM planet_osm_line
           WHERE waterway IN ('dam', 'weir', 'lock_gate')
         ) AS water_barriers_line
@@ -359,7 +374,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, waterway
+            waterway,
+            way
           FROM planet_osm_point
           WHERE waterway IN ('dam', 'weir', 'lock_gate')
         ) AS water_barriers_points
@@ -372,15 +388,17 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, man_made
-          FROM planet_osm_polygon
-          WHERE man_made IN ('pier', 'breakwater', 'groyne')
-          ORDER BY CASE
+            CASE
               WHEN man_made = 'pier' THEN 3
               WHEN man_made = 'groyne' THEN 2
               WHEN man_made = 'breakwater' THEN 1
               ELSE 0
-            END ASC
+            END AS sort_man_made,
+            man_made,
+            way
+          FROM planet_osm_polygon
+          WHERE man_made IN ('pier', 'breakwater', 'groyne')
+          ORDER BY sort_man_made ASC
         ) AS piers_poly
     properties:
       minzoom: 12
@@ -391,15 +409,17 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, man_made
-          FROM planet_osm_line
-          WHERE man_made IN ('pier', 'breakwater', 'groyne')
-          ORDER BY CASE
+            CASE
               WHEN man_made = 'pier' THEN 3
               WHEN man_made = 'groyne' THEN 2
               WHEN man_made = 'breakwater' THEN 1
               ELSE 0
-            END ASC
+            END AS sort_man_made,
+            man_made,
+            way
+          FROM planet_osm_line
+          WHERE man_made IN ('pier', 'breakwater', 'groyne')
+          ORDER BY sort_man_made ASC
         ) AS piers_line
     properties:
       minzoom: 12
@@ -410,8 +430,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            man_made
+            man_made,
+            way
           FROM planet_osm_polygon
           WHERE man_made = 'bridge'
         ) AS bridge
@@ -424,7 +444,7 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            COALESCE(layer,0) AS layernotnull, -- sort keys first, geometry last: see roads_sql
+            COALESCE(layer,0) AS layernotnull,
             way_area,
             building,
             amenity,
@@ -474,7 +494,6 @@ Layer:
             way
           FROM ( -- subselect that contains both roads and rail
             SELECT
-                way,
                 'highway_' || (CASE WHEN highway = 'path' THEN carto_path_type(bicycle, horse) ELSE highway END) AS feature,
                 tracktype,
                 carto_highway_int_surface(surface) AS int_surface,
@@ -491,13 +510,13 @@ Layer:
                 NULL AS preserved,
                 layer,
                 osm_id,
-                z_order
+                z_order,
+                way
               FROM planet_osm_line
               WHERE (tunnel IN ('yes', 'building_passage', 'avalanche_protector') OR covered = 'yes')
                 AND highway IS NOT NULL -- end of road select
             UNION ALL
             SELECT
-                way,
                 'railway_' || (CASE
                                  -- spur/siding/yard tracks get a feature per railway class, e.g. INT-light_rail-service
                                  WHEN (railway IN ('rail', 'tram', 'light_rail', 'subway', 'funicular', 'narrow_gauge', 'monorail')
@@ -515,14 +534,12 @@ Layer:
                 END AS preserved,
                 layer,
                 osm_id,
-                z_order
+                z_order,
+                way
               FROM planet_osm_line
               WHERE (tunnel IN ('yes', 'building_passage', 'avalanche_protector') OR covered = 'yes')
                 AND (railway NOT IN ('platform') AND railway IS NOT NULL) -- end of rail select
             ) AS features
-          -- The sort keys are the first, fixed-width columns and the geometry the last one on
-          -- purpose: comparing rows in the sort otherwise has to step over the geometry to reach
-          -- each key, which made the sort the largest cost of this query.
           ORDER BY
             layernotnull, z_order, sort_rail, sort_service, sort_access, sort_surface, osm_id
         ) AS tunnels
@@ -537,10 +554,11 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-          way
+            COALESCE(layer,0) AS layernotnull,
+            way
           FROM planet_osm_line
           WHERE leisure = 'track'
-          ORDER BY COALESCE(layer,0)
+          ORDER BY layernotnull
         ) AS leisure_track
     properties:
       minzoom: 16
@@ -551,10 +569,10 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
             landuse,
             military,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
+            way
           FROM planet_osm_polygon
           WHERE (landuse = 'military'
             OR military = 'danger_area')
@@ -569,26 +587,28 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, COALESCE(historic, barrier) AS feature
+            COALESCE(historic, barrier) AS feature,
+            way
           FROM
-            (SELECT way,
-              ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
+            (SELECT
+                ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
                     'handrail', 'hedge', 'retaining_wall', 'wall') THEN barrier END)) AS barrier,
-              ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic END)) AS historic
+                ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic END)) AS historic,
+                way
               FROM
                 (SELECT
-                    way,
                     historic,
                     barrier,
-                    waterway
+                    waterway,
+                    way
                   FROM planet_osm_polygon
                   WHERE way && !bbox!
                 UNION ALL
                 SELECT
-                    way,
                     historic,
                     barrier,
-                    waterway
+                    waterway,
+                    way
                   FROM planet_osm_line
                   WHERE way && !bbox!
                 ) _
@@ -607,7 +627,9 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, "natural", man_made
+            "natural",
+            man_made,
+            way
           FROM planet_osm_line
           WHERE "natural" IN ('arete', 'cliff', 'ridge') OR man_made = 'embankment'
         ) AS cliffs
@@ -635,11 +657,15 @@ Layer:
       <<: *osm2pgsql
       table: &turning-circle_sql |-
         (SELECT DISTINCT ON (way)
-            way, type, int_surface, int_tc_type, int_tc_service
+            z_order,
+            CASE WHEN int_surface = 'unpaved' THEN 1 ELSE 0 END AS sort_surface,
+            type,
+            int_surface,
+            int_tc_type,
+            int_tc_service,
+            way
             FROM
               (SELECT
-                -- Valid line geometry requires at least two points that are NOT identical, therefore moving them slightly.
-                ST_MakeLine(ST_Translate(p.way, -0.0001, -0.0001), ST_Translate(p.way, 0.0001, 0.0001)) AS way,
                 p.highway AS type,
                 carto_highway_int_surface(surface) AS int_surface,
                 l.highway AS int_tc_type,
@@ -647,7 +673,9 @@ Layer:
                   THEN 'INT-minor'
                   ELSE 'INT-normal'
                 END AS int_tc_service,
-                l.z_order AS z_order
+                l.z_order AS z_order,
+                -- Valid line geometry requires at least two points that are NOT identical, therefore moving them slightly.
+                ST_MakeLine(ST_Translate(p.way, -0.0001, -0.0001), ST_Translate(p.way, 0.0001, 0.0001)) AS way
               FROM planet_osm_point p
                 JOIN planet_osm_line l
                   ON ST_DWithin(p.way, l.way, 0.1) -- Assumes Mercator
@@ -659,7 +687,7 @@ Layer:
           ORDER BY
             way,
             z_order DESC,
-            CASE WHEN int_surface = 'unpaved' THEN 1 ELSE 0 END 
+            sort_surface
         ) AS turning_circle_sql
     properties:
       minzoom: 15
@@ -670,20 +698,22 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            COALESCE(layer,0) AS layernotnull,
+            way_area,
             COALESCE((
               'highway_' || (CASE WHEN highway IN ('pedestrian', 'footway', 'service', 'platform') THEN highway END)),
               ('railway_' || (CASE WHEN (railway IN ('platform')
                               AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                               AND (tunnel NOT IN ('yes', 'building_passage', 'avalanche_protector') OR tunnel IS NULL))
                               THEN railway END))
-            ) AS feature
+            ) AS feature,
+            way
           FROM planet_osm_polygon
           WHERE highway IN ('pedestrian', 'footway', 'service', 'platform')
             OR (railway IN ('platform')
                 AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                 AND (tunnel NOT IN ('yes', 'building_passage', 'avalanche_protector') OR tunnel IS NULL))
-          ORDER BY COALESCE(layer,0), way_area DESC
+          ORDER BY layernotnull, way_area DESC
         ) AS highway_area_casing
     properties:
       minzoom: 14
@@ -721,7 +751,6 @@ Layer:
             way
           FROM ( -- subselect that contains both roads and rail/aero
             SELECT
-                way,
                 'highway_' || (CASE WHEN highway = 'path' THEN carto_path_type(bicycle, horse) ELSE highway END) AS feature,
                 tracktype,
                 carto_highway_int_surface(surface) AS int_surface,
@@ -738,7 +767,8 @@ Layer:
                 NULL AS preserved,
                 layer,
                 osm_id,
-                z_order
+                z_order,
+                way
               FROM planet_osm_line
               WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage', 'avalanche_protector'))
                 AND (covered IS NULL OR NOT covered = 'yes')
@@ -746,7 +776,6 @@ Layer:
                 AND highway IS NOT NULL -- end of road select
             UNION ALL
             SELECT
-                way,
                 'railway_' || (CASE
                                  -- spur/siding/yard tracks get a feature per railway class, e.g. INT-light_rail-service
                                  WHEN (railway IN ('rail', 'tram', 'light_rail', 'subway', 'funicular', 'narrow_gauge', 'monorail')
@@ -764,7 +793,8 @@ Layer:
                 END AS preserved,
                 layer,
                 osm_id,
-                z_order
+                z_order,
+                way
               FROM planet_osm_line
               WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage', 'avalanche_protector'))
                 AND (covered IS NULL OR NOT covered = 'yes' OR railway IN ('platform'))
@@ -772,9 +802,6 @@ Layer:
                 AND (railway NOT IN ('platform') OR (tags->'location' NOT IN ('underground')) OR (tags->'location') IS NULL)
                 AND railway IS NOT NULL -- end of rail select
             ) AS features
-          -- The sort keys are the first, fixed-width columns and the geometry the last one on
-          -- purpose: comparing rows in the sort otherwise has to step over the geometry to reach
-          -- each key, which made the sort the largest cost of this query.
           ORDER BY
             layernotnull, z_order, sort_rail, sort_service, sort_access, sort_surface, osm_id
         ) AS roads_sql
@@ -788,7 +815,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            COALESCE(layer,0) AS layernotnull,
+            way_area,
             COALESCE(
               ('highway_' || (CASE WHEN highway IN ('pedestrian', 'footway', 'service', 'living_street',
                                                     'platform', 'services') THEN highway END)),
@@ -798,14 +826,15 @@ Layer:
                               THEN railway END)),
               (('aeroway_' || CASE WHEN aeroway IN ('runway', 'taxiway', 'helipad') THEN aeroway ELSE NULL END))
             ) AS feature,
-            carto_highway_int_surface(surface) AS int_surface
+            carto_highway_int_surface(surface) AS int_surface,
+            way
           FROM planet_osm_polygon
           WHERE highway IN ('pedestrian', 'footway', 'service', 'living_street', 'platform', 'services')
             OR (railway IN ('platform')
                 AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                 AND (tunnel NOT IN ('yes', 'building_passage', 'avalanche_protector') OR tunnel IS NULL))
             OR aeroway IN ('runway', 'taxiway', 'helipad')
-          ORDER BY COALESCE(layer,0), way_area desc
+          ORDER BY layernotnull, way_area desc
         ) AS highway_area_fill
     properties:
       minzoom: 14
@@ -894,7 +923,6 @@ Layer:
             way
           FROM ( -- subselect that contains both roads and rail/aero
             SELECT
-                way,
                 'highway_' || (CASE WHEN highway = 'path' THEN carto_path_type(bicycle, horse) ELSE highway END) AS feature,
                 tracktype,
                 carto_highway_int_surface(surface) AS int_surface,
@@ -912,13 +940,13 @@ Layer:
                 NULL AS int_intermittent,
                 layer,
                 osm_id,
-                z_order
+                z_order,
+                way
               FROM planet_osm_line
               WHERE bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct')
                 AND highway IS NOT NULL -- end of road select
             UNION ALL
             SELECT
-                way,
                 'railway_' || (CASE
                                  -- spur/siding/yard tracks get a feature per railway class, e.g. INT-light_rail-service
                                  WHEN (railway IN ('rail', 'tram', 'light_rail', 'subway', 'funicular', 'narrow_gauge', 'monorail')
@@ -937,13 +965,13 @@ Layer:
                 NULL AS int_intermittent,
                 layer,
                 osm_id,
-                z_order
+                z_order,
+                way
               FROM planet_osm_line
               WHERE bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct')
                 AND railway IS NOT NULL -- end of rail select
             UNION ALL
             SELECT          
-                way,
                 'waterway_' || waterway AS feature,
                 NULL AS tracktype,
                 NULL AS int_surface,
@@ -957,16 +985,14 @@ Layer:
                   THEN 'yes' ELSE 'no' END AS int_intermittent,
                 layer,
                 osm_id,
-                0 AS z_order  -- consistent with waterways being rendered before roads/railways
+                0 AS z_order, -- consistent with waterways being rendered before roads/railways
+                way
               FROM planet_osm_line
               WHERE Z(!scale_denominator!) >= 12  -- high zoom water lines start at Z12 rather than Z10
                 AND waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
                 AND (bridge IN ('yes', 'aqueduct') OR (waterway = 'fish_pass'))
                 AND (tunnel IS NULL OR tunnel NOT IN ('yes', 'culvert', 'flooded'))
             ) AS features
-          -- The sort keys are the first, fixed-width columns and the geometry the last one on
-          -- purpose: comparing rows in the sort otherwise has to step over the geometry to reach
-          -- each key, which made the sort the largest cost of this query.
           ORDER BY
             layernotnull, z_order, sort_rail, sort_service, sort_access, sort_surface, osm_id
         ) AS bridges
@@ -981,17 +1007,20 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            aeroway,
+            CASE WHEN aeroway = 'runway' THEN 1 ELSE 0 END AS sort_aeroway,
+            CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',
+                                  'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 0 ELSE 1 END AS sort_surface,
+            osm_id,
             bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct') AS bridge,
-            carto_highway_int_surface(surface) AS int_surface
+            aeroway,
+            carto_highway_int_surface(surface) AS int_surface,
+            way
           FROM planet_osm_line
           WHERE aeroway IN ('runway', 'taxiway')
           ORDER BY
             bridge NULLS FIRST,
-            CASE WHEN aeroway = 'runway' THEN 1 ELSE 0 END,
-            CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',
-                                  'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 0 ELSE 1 END,
+            sort_aeroway,
+            sort_surface,
             osm_id
         ) AS aeroways
     properties:
@@ -1004,10 +1033,11 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
+            COALESCE(layer,0) AS layernotnull,
             way
           FROM planet_osm_line
           WHERE tags @> 'attraction=>water_slide'
-          ORDER BY COALESCE(layer,0)
+          ORDER BY layernotnull
         ) AS waterslide
     properties:
       minzoom: 16
@@ -1018,9 +1048,9 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
             CASE WHEN (tunnel IN ('yes', 'building_passage') OR covered = 'yes' OR tags->'indoor' = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,
-            CASE WHEN (bridge = 'yes' OR bridge = 'covered' OR bridge = 'viaduct') THEN 'yes' ELSE 'no' END AS bridge
+            CASE WHEN (bridge = 'yes' OR bridge = 'covered' OR bridge = 'viaduct') THEN 'yes' ELSE 'no' END AS bridge,
+            way
           FROM planet_osm_line
           WHERE tags @> 'roller_coaster=>track' AND railway IS NULL
         ) AS roller_coaster
@@ -1033,10 +1063,10 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
             COALESCE(layer,0) AS layernotnull,
             CASE WHEN (tunnel IN ('yes', 'building_passage') OR covered = 'yes' OR tags->'indoor' = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,
-            CASE WHEN (bridge = 'yes' OR bridge = 'covered' OR bridge = 'viaduct') THEN 'yes' ELSE 'no' END AS bridge
+            CASE WHEN (bridge = 'yes' OR bridge = 'covered' OR bridge = 'viaduct') THEN 'yes' ELSE 'no' END AS bridge,
+            way
           FROM planet_osm_line
           WHERE tags @> 'roller_coaster=>track' AND railway IS NULL
           ORDER BY
@@ -1052,10 +1082,16 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            CASE
+              WHEN man_made IN ('goods_conveyor', 'pipeline') THEN 1
+              WHEN tags-> 'location' = 'overhead' THEN 2
+              WHEN bridge IS NOT NULL THEN 3
+              WHEN aerialway IS NOT NULL THEN 4
+            END AS sort_feature,
             aerialway,
             man_made,
-            tags->'substance' AS substance
+            tags->'substance' AS substance,
+            way
           FROM planet_osm_line
           WHERE aerialway IS NOT NULL
             OR (man_made = 'pipeline'
@@ -1065,12 +1101,7 @@ Layer:
                 AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                 AND (tunnel NOT IN ('yes') OR tunnel IS NULL))
           ORDER BY
-            CASE
-              WHEN man_made IN ('goods_conveyor', 'pipeline') THEN 1
-              WHEN tags-> 'location' = 'overhead' THEN 2
-              WHEN bridge IS NOT NULL THEN 3
-              WHEN aerialway IS NOT NULL THEN 4
-            END
+            sort_feature
         ) AS aerialways
     properties:
       minzoom: 12
@@ -1081,9 +1112,9 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
             tags->'entrance' AS entrance,
-            access
+            access,
+            way
           FROM planet_osm_point
           WHERE tags ? 'entrance'
             AND (
@@ -1100,7 +1131,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, tags->'golf' AS golf
+            tags->'golf' AS golf,
+            way
           FROM planet_osm_line
           WHERE tags @> 'golf=>hole'
         ) AS golf_line
@@ -1113,8 +1145,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            carto_filter_antimeridian(way) AS way,
-            admin_level
+            admin_level,
+            carto_filter_antimeridian(way) AS way
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4')
@@ -1132,8 +1164,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            carto_filter_antimeridian(way) AS way,
-            admin_level
+            admin_level,
+            carto_filter_antimeridian(way) AS way
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')
@@ -1151,14 +1183,15 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            carto_filter_antimeridian(way) AS way,
-            admin_level
+            admin_level::integer AS admin_level_numeric,
+            admin_level,
+            carto_filter_antimeridian(way) AS way
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
             AND osm_id < 0
             AND way && !bbox!
-          ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
+          ORDER BY admin_level_numeric DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
         ) AS admin_high_zoom
     properties:
       minzoom: 13
@@ -1195,9 +1228,9 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
-            tourism
+            tourism,
+            way
           FROM planet_osm_polygon
           WHERE tourism = 'theme_park'
             OR tourism = 'zoo'
@@ -1211,10 +1244,10 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
             boundary,
             tags->'protect_class' AS protect_class,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
+            way
           FROM planet_osm_polygon
           WHERE (boundary IN ('aboriginal_lands', 'national_park')
                  OR leisure = 'nature_reserve'
@@ -1232,12 +1265,14 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, "natural"
+            "natural",
+            way
           FROM planet_osm_point
           WHERE "natural" = 'tree'
         UNION ALL
         SELECT
-            way, "natural"
+            "natural",
+            way
           FROM planet_osm_line
           WHERE "natural" = 'tree_row'
         ) AS trees
@@ -1255,12 +1290,13 @@ Layer:
       # results for most countries.
       table: |-
         (SELECT
+            way_area,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
+            name,
             (SELECT ST_Transform(ST_PointOnSurface(geom),3857)
               FROM ST_Dump(ST_Transform(way,4326))
               ORDER BY ST_Area(geom::geography) DESC
-              LIMIT 1) AS way,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
-            name
+              LIMIT 1) AS way
           FROM planet_osm_polygon
           WHERE way && !bbox!
             AND name IS NOT NULL
@@ -1280,12 +1316,12 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            name,
             CASE
               WHEN (tags->'population' ~ '^[0-9]{1,8}$') THEN (tags->'population')::INTEGER ELSE 0
             END as population,
-            round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles
+            name,
+            round(ascii(md5(osm_id::text)) / 55) AS dir, -- base direction factor on geometry to be consistent across metatiles
+            way
           FROM planet_osm_point
           WHERE place IN ('city', 'town', 'village', 'hamlet')
             AND name IS NOT NULL
@@ -1302,11 +1338,12 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            ST_PointOnSurface(way) AS way,
+            way_area,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             name,
             admin_level,
-            ref
+            ref,
+            ST_PointOnSurface(way) AS way
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
             AND name IS NOT NULL
@@ -1326,18 +1363,18 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            name,
             score,
+            length(name) AS name_length,
+            name,
             CASE
               WHEN (place = 'city') THEN 1
               ELSE 2
             END as category,
-            round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles
+            round(ascii(md5(osm_id::text)) / 55) AS dir, -- base direction factor on geometry to be consistent across metatiles
+            way
           FROM
             (SELECT
                 osm_id,
-                way,
                 place,
                 name,
                 (
@@ -1352,13 +1389,14 @@ Layer:
                     WHEN (tags @> 'capital=>4') THEN 2
                     ELSE 1
                   END)
-                ) AS score
+                ) AS score,
+                way
               FROM planet_osm_point
               WHERE place IN ('city', 'town')
                 AND name IS NOT NULL
                 AND NOT (tags @> 'capital=>yes')
             ) as p
-          ORDER BY score DESC, length(name) DESC, name
+          ORDER BY score DESC, name_length DESC, name
         ) AS placenames_medium
     properties:
       cache-features: true
@@ -1371,16 +1409,7 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            place,
-            name
-          FROM planet_osm_point
-          WHERE place IN ('village', 'hamlet')
-             AND name IS NOT NULL
-             AND NOT tags @> 'capital=>yes'
-             OR (place IN ('suburb', 'quarter', 'neighbourhood', 'isolated_dwelling', 'farm')
-             ) AND name IS NOT NULL
-          ORDER BY CASE
+            CASE
               WHEN place = 'suburb' THEN 7
               WHEN place = 'village' THEN 6
               WHEN place = 'hamlet' THEN 5
@@ -1388,8 +1417,19 @@ Layer:
               WHEN place = 'neighbourhood' THEN 3
               WHEN place = 'isolated_dwelling' THEN 2
               WHEN place = 'farm' THEN 1
-            END DESC,
-            length(name) DESC,
+            END AS sort_place,
+            length(name) AS name_length,
+            name,
+            place,
+            way
+          FROM planet_osm_point
+          WHERE place IN ('village', 'hamlet')
+             AND name IS NOT NULL
+             AND NOT tags @> 'capital=>yes'
+             OR (place IN ('suburb', 'quarter', 'neighbourhood', 'isolated_dwelling', 'farm')
+             ) AND name IS NOT NULL
+          ORDER BY sort_place DESC,
+            name_length DESC,
             name
         ) AS placenames_small
     properties:
@@ -1402,35 +1442,42 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            CASE railway
+              WHEN 'station' THEN 1
+              WHEN 'subway_entrance' THEN 3
+              ELSE 2
+            END AS sort_railway,
+            way_area,
+            osm_id,
             name,
             ref,
             railway,
             aerialway,
-            station
+            station,
+            way
           FROM
           (SELECT
-              ST_PointOnSurface(way) AS way,
               name,
               ref,
               railway,
               aerialway,
               tags->'station' AS station,
               way_area,
-              osm_id
+              osm_id,
+              ST_PointOnSurface(way) AS way
             FROM planet_osm_polygon
             WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
               AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
           UNION ALL
           SELECT
-              way,
               name,
               ref,
               railway,
               aerialway,
               tags->'station' AS station,
               NULL::real AS way_area,
-              osm_id
+              osm_id,
+              way
             FROM planet_osm_point
             WHERE way && !bbox!
             ) _
@@ -1438,11 +1485,7 @@ Layer:
             OR railway = 'subway_entrance' AND way_area IS NULL
             OR aerialway = 'station'
           ORDER BY
-            CASE railway
-              WHEN 'station' THEN 1
-              WHEN 'subway_entrance' THEN 3
-              ELSE 2
-            END,
+            sort_railway,
             way_area DESC NULLS LAST,
             osm_id
         ) AS stations
@@ -1463,9 +1506,14 @@ Layer:
             -- the node's name from z14 onward so junctions with different names
             -- don't merge; at lower zooms it is NULL and only stripped_ref
             -- decides clustering.
-            SELECT way, highway, junction, ref, name,
+            SELECT
+                highway,
+                junction,
+                ref,
+                name,
                 regexp_replace(ref, '^([0-9]+)[A-Za-z]$', '\1') AS stripped_ref,
-                CASE WHEN Z(!scale_denominator!) >= 14 THEN NULLIF(name, '') END AS visible_name
+                CASE WHEN Z(!scale_denominator!) >= 14 THEN NULLIF(name, '') END AS visible_name,
+                way
               FROM planet_osm_point
               WHERE way && ST_Expand(!bbox!, 40 * !scale_denominator! * 0.001 * 0.28)
                 AND highway = 'motorway_junction'
@@ -1474,24 +1522,31 @@ Layer:
             -- Combine any pair of motorway_junctions sharing the same
             -- (stripped_ref, visible_name) within 40 px. cid is the cluster id,
             -- or NULL if the point was alone.
-            SELECT *,
+            SELECT
+                highway,
+                junction,
+                ref,
+                name,
+                stripped_ref,
+                visible_name,
                 CASE WHEN Z(!scale_denominator!) < 17
                   THEN ST_ClusterDBSCAN(
                     way,
                     eps => 40 * !scale_denominator! * 0.001 * 0.28, -- combine within 40px distance
                     minpoints => 2 -- at least two points are needed to make a cluster
                   ) OVER (PARTITION BY stripped_ref, visible_name)
-                END AS cid
+                END AS cid,
+                way
               FROM mj
           )
           -- Standalone motorway_junctions (no cluster peer): emit unchanged.
           SELECT
-              way,
+              NULL::float AS way_pixels,
               highway,
               junction,
               ref,
               name,
-              NULL::float AS way_pixels
+              way
             FROM mj_clustered
             WHERE cid IS NULL
         UNION ALL
@@ -1504,38 +1559,46 @@ Layer:
           -- nodes with no ref): cluster_min_ref is NULL and every row matches,
           -- so the centroid averages all node positions.
           SELECT
-              ST_Centroid(ST_Collect(way) FILTER (WHERE ref IS NOT DISTINCT FROM cluster_min_ref)) AS way,
+              NULL::float AS way_pixels,
               MIN(highway) AS highway,
               MIN(junction) AS junction,
               MIN(ref) AS ref,
               MIN(name) AS name,
-              NULL::float AS way_pixels
+              ST_Centroid(ST_Collect(way) FILTER (WHERE ref IS NOT DISTINCT FROM cluster_min_ref)) AS way
             FROM (
-              SELECT *,
-                  MIN(ref) OVER (PARTITION BY stripped_ref, visible_name, cid) AS cluster_min_ref
+              SELECT
+                  highway,
+                  junction,
+                  ref,
+                  name,
+                  stripped_ref,
+                  visible_name,
+                  cid,
+                  MIN(ref) OVER (PARTITION BY stripped_ref, visible_name, cid) AS cluster_min_ref,
+                  way
                 FROM mj_clustered
                 WHERE cid IS NOT NULL
             ) c
             GROUP BY stripped_ref, visible_name, cid
         UNION ALL
           SELECT
-            way,
+            NULL::float AS way_pixels,
             highway,
             junction,
             ref,
             name,
-            NULL::float AS way_pixels
+            way
           FROM planet_osm_point
           WHERE way && !bbox!
             AND (highway = 'traffic_signals' OR junction = 'yes')
         UNION ALL
           SELECT
-            ST_PointOnSurface(way) AS way,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             highway,
             junction,
             ref,
             name,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+            ST_PointOnSurface(way) AS way
           FROM planet_osm_polygon
           WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
             AND junction = 'yes'
@@ -1551,10 +1614,11 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            ST_PointOnSurface(way) AS way,
+            way_area,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             man_made,
-            name
+            name,
+            ST_PointOnSurface(way) AS way
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
             AND name IS NOT NULL
@@ -1572,10 +1636,11 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            ST_PointOnSurface(way) AS way,
+            way_area,
+            admin_level,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             name,
-            admin_level
+            ST_PointOnSurface(way) AS way
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
             AND name IS NOT NULL
@@ -1600,7 +1665,19 @@ Layer:
             *
           FROM
           (SELECT -- This subselect allows filtering on the feature column
-              CASE WHEN way_area IS NOT NULL THEN ST_PointOnSurface(way) ELSE way END AS way,
+              CASE
+                WHEN "natural" IN ('peak', 'volcano', 'saddle')
+                     OR tags->'mountain_pass' = 'yes' THEN
+                  CASE
+                    WHEN tags->'ele' ~ '^-?\d{1,4}(\.\d+)?$' THEN (tags->'ele')::NUMERIC
+                  END
+                WHEN "waterway" IN ('waterfall') THEN
+                  CASE
+                    WHEN tags->'height' ~ '^\d{1,3}(\.\d+)?( m)?$' THEN (SUBSTRING(tags->'height', '^(\d{1,3}(\.\d+)?)( m)?$'))::NUMERIC
+                  END
+              END AS score,
+              COALESCE(way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0), 0) AS way_pixels,
+              osm_id,
               CASE
                 WHEN amenity = 'parcel_locker'
                 THEN CONCAT_WS(E'\n', COALESCE(tags->'brand', tags->'operator', name), ref)
@@ -1691,17 +1768,6 @@ Layer:
                 'golf_' || CASE WHEN tags->'golf' IN ('pin') AND way_area IS NULL THEN tags->'golf' END
               ) AS feature,
               CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS int_access,
-              CASE
-                WHEN "natural" IN ('peak', 'volcano', 'saddle') 
-                     OR tags->'mountain_pass' = 'yes' THEN
-                  CASE
-                    WHEN tags->'ele' ~ '^-?\d{1,4}(\.\d+)?$' THEN (tags->'ele')::NUMERIC
-                  END
-                WHEN "waterway" IN ('waterfall') THEN
-                  CASE
-                    WHEN tags->'height' ~ '^\d{1,3}(\.\d+)?( m)?$' THEN (SUBSTRING(tags->'height', '^(\d{1,3}(\.\d+)?)( m)?$'))::NUMERIC
-                  END
-              END AS score,
               religion,
               tags->'denomination' as denomination,
               tags->'generator:source' as "generator:source",
@@ -1747,11 +1813,9 @@ Layer:
               tags->'operator' AS operator,
               ref,
               way_area,
-              COALESCE(way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0), 0) AS way_pixels,
-              osm_id
+              CASE WHEN way_area IS NOT NULL THEN ST_PointOnSurface(way) ELSE way END AS way
             FROM
               (SELECT
-                  way,
                   name,
                   access,
                   aeroway,
@@ -1775,13 +1839,13 @@ Layer:
                   waterway,
                   tags,
                   way_area,
-                  osm_id
+                  osm_id,
+                  way
                 FROM planet_osm_polygon
                 WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
                   AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
               UNION ALL
               SELECT
-                  way,
                   name,
                   access,
                   aeroway,
@@ -1805,7 +1869,8 @@ Layer:
                   waterway,
                   tags,
                   NULL::real AS way_area,
-                  osm_id
+                  osm_id,
+                  way
                 FROM planet_osm_point
                 WHERE way && !bbox!
               ) _
@@ -1825,12 +1890,12 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-          way,
           COALESCE(
            'highway_' || CASE WHEN tags->'ford' IN ('yes', 'stepping_stones') THEN 'ford' END,
            'leisure_' || CASE WHEN leisure = 'slipway' THEN leisure END,
            'man_made_' || CASE WHEN man_made = 'ceremonial_gate' THEN man_made END
-            ) AS feature
+            ) AS feature,
+          way
           FROM planet_osm_line
           -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering
           WHERE tags->'ford' IN ('yes', 'stepping_stones')
@@ -1846,17 +1911,26 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-          *
+            CASE int_isminor
+              WHEN 'no' THEN 1
+              WHEN 'incomplete' THEN 2
+              ELSE 3
+            END AS sort_minor,
+            CASE WHEN railway = 'crossing' THEN 1 ELSE 2 END AS sort_crossing,
+            osm_id,
+            railway,
+            int_isminor,
+            way
           FROM
             (SELECT
-              crossing.way AS way,
               crossing.railway AS railway,
               CASE
                 WHEN track.railway IS NULL THEN 'incomplete'
                 WHEN track.railway IN ('disused', 'tram', 'miniature') OR track.service IN ('spur', 'siding', 'yard') THEN 'yes'
                 ELSE 'no'
               END AS int_isminor,
-              crossing.osm_id
+              crossing.osm_id,
+              crossing.way AS way
             FROM planet_osm_point crossing
             LEFT JOIN planet_osm_line track
               ON track.railway IS NOT NULL
@@ -1865,11 +1939,8 @@ Layer:
               AND crossing.way && !bbox!
             ) _
           ORDER BY
-            CASE int_isminor 
-              WHEN 'no' THEN 1
-              WHEN 'incomplete' THEN 2
-              ELSE 3 END,
-            CASE WHEN railway = 'crossing' THEN 1 ELSE 2 END,
+            sort_minor,
+            sort_crossing,
             osm_id
         ) AS railway_crossings
     properties:
@@ -1881,15 +1952,16 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            power
+            CASE power
+              WHEN 'tower' THEN 2
+              WHEN 'pole' THEN 1
+            END AS sort_power,
+            power,
+            way
         FROM planet_osm_point
         WHERE power IN ('tower', 'pole')
         ORDER BY
-          CASE power
-            WHEN 'tower' THEN 2
-            WHEN 'pole' THEN 1
-          END DESC
+          sort_power DESC
         ) AS power_towers
     properties:
       minzoom: 14
@@ -1900,37 +1972,39 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            highway,
+            CASE
+              WHEN highway = 'motorway' THEN 38
+              WHEN highway = 'trunk' THEN 37
+              WHEN highway = 'primary' THEN 36
+              WHEN highway = 'secondary' THEN 35
+            END AS sort_highway,
             height,
             width,
-            refs
+            osm_id,
+            refs,
+            highway,
+            way
           FROM (
             SELECT
-                way,
                 osm_id,
                 highway,
                 array_length(refs,1) AS height,
                 (SELECT MAX(char_length(ref)) FROM unnest(refs) AS u(ref)) AS width,
-                array_to_string(refs, E'\n') AS refs
+                array_to_string(refs, E'\n') AS refs,
+                way
               FROM (
                 SELECT
-                    way,
                     osm_id,
                     highway,
-                    string_to_array(ref, ';') AS refs
+                    string_to_array(ref, ';') AS refs,
+                    way
                 FROM planet_osm_roads
                   WHERE highway IN ('motorway', 'trunk', 'primary', 'secondary')
                   AND ref IS NOT NULL
               ) AS p) AS q
           WHERE height <= 4 AND width <= 11
           ORDER BY
-            CASE
-              WHEN highway = 'motorway' THEN 38
-              WHEN highway = 'trunk' THEN 37
-              WHEN highway = 'primary' THEN 36
-              WHEN highway = 'secondary' THEN 35
-            END DESC NULLS LAST,
+            sort_highway DESC NULLS LAST,
             height DESC,
             width DESC,
             refs,
@@ -1946,34 +2020,6 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            highway,
-            height,
-            width,
-            refs
-          FROM (
-            SELECT
-                osm_id,
-                way,
-                highway,
-                array_length(refs,1) AS height,
-                (SELECT MAX(char_length(ref)) FROM unnest(refs) AS u(ref)) AS width,
-                array_to_string(refs, E'\n') AS refs
-              FROM (
-                SELECT
-                    osm_id,
-                    way,
-                    COALESCE(
-                      CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') THEN highway END,
-                      CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway END
-                    ) AS highway,
-                    string_to_array(ref, ';') AS refs
-                  FROM planet_osm_line
-                  WHERE (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') OR aeroway IN ('runway', 'taxiway'))
-                    AND ref IS NOT NULL
-              ) AS p) AS q
-          WHERE height <= 4 AND width <= 11
-          ORDER BY
             CASE
               WHEN highway = 'motorway' THEN 38
               WHEN highway = 'trunk' THEN 37
@@ -1982,7 +2028,37 @@ Layer:
               WHEN highway = 'tertiary' THEN 34
               WHEN highway = 'runway' THEN 6
               WHEN highway = 'taxiway' THEN 5
-            END DESC NULLS LAST,
+            END AS sort_highway,
+            height,
+            width,
+            osm_id,
+            refs,
+            highway,
+            way
+          FROM (
+            SELECT
+                osm_id,
+                highway,
+                array_length(refs,1) AS height,
+                (SELECT MAX(char_length(ref)) FROM unnest(refs) AS u(ref)) AS width,
+                array_to_string(refs, E'\n') AS refs,
+                way
+              FROM (
+                SELECT
+                    osm_id,
+                    COALESCE(
+                      CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') THEN highway END,
+                      CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway END
+                    ) AS highway,
+                    string_to_array(ref, ';') AS refs,
+                    way
+                  FROM planet_osm_line
+                  WHERE (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') OR aeroway IN ('runway', 'taxiway'))
+                    AND ref IS NOT NULL
+              ) AS p) AS q
+          WHERE height <= 4 AND width <= 11
+          ORDER BY
+            sort_highway DESC NULLS LAST,
             height DESC,
             width DESC,
             refs,
@@ -1997,10 +2073,11 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            ST_PointOnSurface(way) AS way,
+            way_area,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             highway,
-            name
+            name,
+            ST_PointOnSurface(way) AS way
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
             AND name IS NOT NULL
@@ -2022,7 +2099,7 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            z_order, -- sort keys first, geometry last: see roads_sql
+            z_order,
             COALESCE(layer, 0) AS layernotnull,
             length(name) AS name_length,
             l.osm_id,
@@ -2058,14 +2135,14 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
             CASE WHEN highway = 'path' THEN carto_path_type(bicycle, horse) ELSE highway END AS highway,
             construction,
             name,
             CASE
               WHEN oneway IN ('yes', '-1') THEN oneway
               WHEN junction IN ('roundabout') AND (oneway IS NULL OR NOT oneway IN ('no', 'reversible')) THEN 'yes'
-            END AS oneway
+            END AS oneway,
+            way
           FROM planet_osm_line
           WHERE highway IN ('bridleway', 'footway', 'cycleway', 'path', 'track', 'steps', 'construction')
             AND (name IS NOT NULL
@@ -2082,7 +2159,11 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            z_order,
+            COALESCE(layer, 0) AS layernotnull,
+            length(name) AS name_length,
+            l.osm_id,
+            name,
             CASE
               WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-rail-service'
               WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-tram-service'
@@ -2091,11 +2172,11 @@ Layer:
             tags->'highspeed' as highspeed,
             tags->'usage' as usage,
             construction,
-            name,
             (CASE
               WHEN tags->'railway:preserved' = 'yes' THEN 'yes'
               ELSE 'no'
-            END) AS preserved
+            END) AS preserved,
+            way
           FROM planet_osm_line l
           WHERE railway IN ('rail', 'subway', 'narrow_gauge', 'light_rail', 'funicular', 'monorail', 'miniature', 'tram', 'disused', 'construction')
             AND (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage', 'avalanche_protector'))
@@ -2103,10 +2184,10 @@ Layer:
             AND name IS NOT NULL
           ORDER BY
             z_order DESC, -- put important rails first
-            COALESCE(layer, 0), -- put top layered rails first
-            length(name) DESC, -- Try to fit big labels in first
+            layernotnull, -- put top layered rails first
+            name_length DESC, -- Try to fit big labels in first
             name DESC, -- Force a consistent ordering between differently named railways
-            l.osm_id DESC -- Force an ordering for railways of the same name, e.g. dualized rails
+            osm_id DESC -- Force an ordering for railways of the same name, e.g. dualized rails
         ) AS railways_text_name
     properties:
       minzoom: 11
@@ -2117,36 +2198,38 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            highway,
+            CASE
+              WHEN highway = 'unclassified' THEN 33
+              WHEN highway = 'residential' THEN 32
+              WHEN highway = 'track' THEN 30
+            END AS sort_highway,
             height,
             width,
-            refs
+            osm_id,
+            refs,
+            highway,
+            way
           FROM (
             SELECT
                 osm_id,
-                way,
                 highway,
                 array_length(refs,1) AS height,
                 (SELECT MAX(char_length(ref)) FROM unnest(refs) AS u(ref)) AS width,
-                array_to_string(refs, E'\n') AS refs
+                array_to_string(refs, E'\n') AS refs,
+                way
               FROM (
                 SELECT
                     osm_id,
-                    way,
                     CASE WHEN highway IN ('unclassified', 'residential', 'track') THEN highway END AS highway,
-                    string_to_array(ref, ';') AS refs
+                    string_to_array(ref, ';') AS refs,
+                    way
                   FROM planet_osm_line
                   WHERE highway IN ('unclassified', 'residential', 'track')
                     AND ref IS NOT NULL
               ) AS p) AS q
           WHERE height <= 4 AND width <= 11
           ORDER BY
-            CASE
-              WHEN highway = 'unclassified' THEN 33
-              WHEN highway = 'residential' THEN 32
-              WHEN highway = 'track' THEN 30
-            END DESC NULLS LAST,
+            sort_highway DESC NULLS LAST,
             height DESC,
             width DESC,
             refs,
@@ -2161,7 +2244,7 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            ST_PointOnSurface(way) AS way,
+            way_area,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             COALESCE(
               'landuse_' || CASE WHEN landuse IN ('forest', 'military', 'farmland') THEN landuse END,
@@ -2174,7 +2257,8 @@ Layer:
               'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure END
             ) AS feature,
             name,
-            CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building -- always no with the where conditions
+            CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building, -- always no with the where conditions
+            ST_PointOnSurface(way) AS way
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
             AND name IS NOT NULL
@@ -2200,10 +2284,10 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
             COALESCE('aerialway_' || aerialway, 'attraction_' || CASE WHEN tags @> 'attraction=>water_slide' THEN 'water_slide' END, 'leisure_' || leisure, 'man_made_' || man_made, 'waterway_' || waterway, 'natural_' || "natural", 'golf_' || (tags->'golf')) AS feature,
             name,
-            ref
+            ref,
+            way
           FROM planet_osm_line
           WHERE ((man_made IN ('pier', 'breakwater', 'groyne', 'embankment')
               OR (man_made = 'pipeline'
@@ -2237,9 +2321,10 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
+            way_area,
             name,
-            ST_PointOnSurface(way) AS way,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
+            ST_PointOnSurface(way) AS way
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
             AND name IS NOT NULL
@@ -2270,12 +2355,12 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            ST_PointOnSurface(way) AS way,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             carto_shorten_list("addr:housenumber", ',;') AS addr_housenumber,
             "addr:housename" AS addr_housename,
             tags->'addr:unit' AS addr_unit,
-            carto_shorten_list(tags->'addr:flats', ';') AS addr_flats, 
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+            carto_shorten_list(tags->'addr:flats', ';') AS addr_flats,
+            ST_PointOnSurface(way) AS way
           FROM planet_osm_polygon
           WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
             AND (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR tags ? 'addr:unit' OR tags ? 'addr:flats')
@@ -2283,12 +2368,12 @@ Layer:
             AND way_area < 4000000*POW(!scale_denominator!*0.001*0.28,2)
         UNION ALL
         SELECT
-            way,
+            NULL::float AS way_pixels,
             carto_shorten_list("addr:housenumber", ',;') AS addr_housenumber,
             "addr:housename" AS addr_housename,
             tags->'addr:unit' AS addr_unit,
             carto_shorten_list(tags->'addr:flats', ';') AS addr_flats,
-            NULL::float AS way_pixels
+            way
           FROM planet_osm_point
           WHERE way && !bbox!
             AND (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR tags ? 'addr:unit' OR tags ? 'addr:flats')
@@ -2303,7 +2388,7 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            COALESCE(layer,0) AS layernotnull,
             waterway,
             lock,
             name,
@@ -2314,13 +2399,14 @@ Layer:
               THEN 'yes' ELSE 'no' END AS int_intermittent,
             CASE WHEN tunnel IN ('yes', 'culvert') 
               OR waterway = 'canal' AND tunnel = 'flooded'
-              THEN 'yes' ELSE 'no' END AS int_tunnel
+              THEN 'yes' ELSE 'no' END AS int_tunnel,
+            way
           FROM planet_osm_line
           WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass') -- no render for fish_pass but using waterway index for efficiency
                  OR "natural" IN ('bay', 'strait'))
             AND (tunnel IS NULL OR tunnel != 'culvert')
             AND name IS NOT NULL
-          ORDER BY COALESCE(layer,0)
+          ORDER BY layernotnull
         ) AS water_lines_text
     properties:
       minzoom: 13
@@ -2331,8 +2417,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            name
+            name,
+            way
           FROM planet_osm_line
           WHERE route = 'ferry'
             AND osm_id > 0
@@ -2347,17 +2433,19 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            admin_level::integer AS admin_level_numeric,
+            way_area,
             name,
             admin_level,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
+            way
           FROM planet_osm_polygon
           WHERE boundary = 'administrative'
             AND admin_level IN ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
             AND name IS NOT NULL
             AND osm_id < 0
             AND way_area > 196000*POW(!scale_denominator!*0.001*0.28,2)
-          ORDER BY admin_level::integer ASC, way_area DESC
+          ORDER BY admin_level_numeric ASC, way_area DESC
         ) AS admin_text
     properties:
       minzoom: 11
@@ -2368,11 +2456,11 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
             name,
             boundary,
             tags->'protect_class' AS protect_class,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
+            way
           FROM planet_osm_polygon
           WHERE (boundary IN ('aboriginal_lands', 'national_park')
                  OR leisure = 'nature_reserve'
@@ -2388,7 +2476,13 @@ Layer:
       <<: *osm2pgsql
       table: &amenity_low_priority_sql |-
         (SELECT
-            way,
+            CASE amenity
+                WHEN 'waste_basket' THEN 1
+                WHEN 'waste_disposal' THEN 1
+                WHEN 'bench' THEN 2
+                WHEN NULL THEN 3
+              END AS sort_amenity,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             name,
             COALESCE(
               'amenity_' || CASE WHEN amenity IN ('bench', 'waste_basket', 'waste_disposal') AND way_area IS NULL THEN amenity END,
@@ -2398,10 +2492,9 @@ Layer:
             )  AS feature,
             CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS int_access,
             way_area,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+            way
             FROM
               (SELECT
-                  ST_PointOnSurface(way) AS way,
                   name,
                   access,
                   amenity,
@@ -2410,13 +2503,13 @@ Layer:
                   historic,
                   man_made,
                   tags,
-                  way_area
+                  way_area,
+                  ST_PointOnSurface(way) AS way
                 FROM planet_osm_polygon
                 WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
                   AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
               UNION ALL
               SELECT
-                  way,
                   name,
                   access,
                   amenity,
@@ -2425,7 +2518,8 @@ Layer:
                   historic,
                   man_made,
                   tags,
-                  NULL::real AS way_area
+                  NULL::real AS way_area,
+                  way
                 FROM planet_osm_point
                 WHERE way && !bbox!
               ) _
@@ -2434,12 +2528,7 @@ Layer:
                OR man_made IN ('cross')
                OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate')
             ORDER BY
-              CASE amenity
-                WHEN 'waste_basket' THEN 1
-                WHEN 'waste_disposal' THEN 1
-                WHEN 'bench' THEN 2
-                WHEN NULL THEN 3
-              END DESC,
+              sort_amenity DESC,
               way_pixels DESC NULLS LAST
           ) AS amenity_low_priority
     properties:


### PR DESCRIPTION
Changes proposed in this pull request:
- **Rearrange some PostgreSQL to improve efficiency during `ORDER BY`. A sample of 42 metatiles are sped up in terms of total PostgreSQL CPU time by 15%. Rendering is unchanged (the rows that Mapnik receives are unchanged).**

Explanation:

There are two changes made here. First, we reorder the `way` to be after all the columns that affect the `ORDER BY` sort. Second, we rearrange the columns that we'll use for sorting by making them fully fledged columns in the `SELECT`.

Why is this so much faster?

After the projection is completed and we have our final row ("tuple", in this case a `MinimalTuple`), Postgres `tuplesort` is going to complete our desired `ORDER BY` by using a sorting algorithm that (as you'd expect) needs to repeatedly compare pairs of tuples. The `SortTuple` is the actual minimal object that will be swapped around and rearranged into sorted order. But, for comparisons, the code will refer back to the columns of our full `MinimalTuple` by ordinal index, see [here](https://github.com/postgres/postgres/blob/005c1971a2926fbb9caf5a1ad634cd17a42bfd3c/src/backend/executor/nodeSort.c#L97-L122), and see [this block comment in tuplesort](https://github.com/postgres/postgres/blob/005c1971a2926fbb9caf5a1ad634cd17a42bfd3c/src/backend/utils/sort/tuplesort.c#L152-L187). Interestingly, Postgres highly optimizes the first sort key column. For `ORDER BY first_col, ...more_cols...` that first_col will be copied by value into the `SortTuple` (as the `Datum`, in this case all these first sort keys are ints which are `typbyval` so they are actually present by value (not true of later sort keys e.g. `name` which is `text`)). Only if that column is equal will it then fetch the later tiebreaker columns from both tuples being compared using `heap_getattr`. You can see that logic [here](https://github.com/postgres/postgres/blob/005c1971a2926fbb9caf5a1ad634cd17a42bfd3c/src/backend/utils/sort/tuplesort.c#L3904-L3947).

In this case, these queries have leading elements like `layer` and `z_order` which are exactly tied very frequently (there are not so many distinct values). So the point is that we very often have to fall back to `heap_getattr`.

So, prior to this PR, all these `SELECT`s would take the `way` first, which means that the `MinimalTuple` would begin with the `way` which is variable-width. Additionally, the other expressions that we'd sort by, such as `length(name)` or `COALESCE(layer, 0)` or the case expressions, if not already present in the `SELECT`, would be placed at the end after all that in the `resjunk` section, see [here](https://github.com/postgres/postgres/blob/005c1971a2926fbb9caf5a1ad634cd17a42bfd3c/src/backend/parser/parse_clause.c#L2033-L2092). But, it turns out that the `way` being variable-width is slow, because every single comparison of the sort has to seek past it (if the first column is tied). So we'd like for all the columns we sort by to be projected strictly **before** the `way`. But, any computed expression is placed after all our explicit columns. Therefore, that explains the other part of this PR where all computed expressions get fully hoisted up into our `SELECT` - not because they need to be computed once and cached, but just because we need to get it out of the `resjunk` suffix so that it can be ordered before the `way`.

Now this is getting really into the weeds, but the reason why seeking past `way` is slow, is simply that Postgres can cache the byte offset into the `MinimalTuple` if **all columns before it** are predictable fixed width. See that code [here](https://github.com/postgres/postgres/blob/005c1971a2926fbb9caf5a1ad634cd17a42bfd3c/src/backend/access/common/heaptuple.c#L530-L601) to detect the situation. The fast path is [here](https://github.com/postgres/postgres/blob/005c1971a2926fbb9caf5a1ad634cd17a42bfd3c/src/backend/access/common/heaptuple.c#L572-L644) and [here](https://github.com/postgres/postgres/blob/005c1971a2926fbb9caf5a1ad634cd17a42bfd3c/src/include/access/htup_details.h#L749-L775). But if we had preceding it anything variable width or null, then we have to walk through the tuple, column by column, computing the sizeof each column, see [here](https://github.com/postgres/postgres/blob/005c1971a2926fbb9caf5a1ad634cd17a42bfd3c/src/backend/access/common/heaptuple.c#L645-L708). Of course, the `way` is variable width, and skipping over it requires us to repeatedly determine its size in bytes.

So overall, as we sort, we'd like each individual comparison to be really fast, as we'll be doing $`O(n \log n)`$ of them. If we take our entire sort key and put it all at the beginning of the tuple, Postgres can very quickly do `heap_getattr` because they are at a fixed location. This only applies to the 2nd and further sort keys, as the 1st sort key is fully materialized into the `SortTuple`, but that is very relevant to these particular queries because as I said earlier the first sort key is going to tie very frequently.

All the conditions, rows, and sort orders are unchanged. They are just arranged in a slightly different way that makes Postgres significantly happier.

I ran 42 metatiles in a configuration that is as close to tile.osm.org as I could practically get. (see this PR for more info on the testing setup: https://github.com/mapnik/mapnik/pull/4578) The total PostgreSQL CPU time (NOT just the time for these edited queries) is decreased from 329.44s to 280.08s (averaged across 5 runs), a decrease of 15%. The decrease ranged from 14.94% to 15.04% so it was very reliable. PostgreSQL CPU is the relevant measurement here because the optimization does not change the rows delivered to Mapnik or the rendering work performed afterward. When I reweight the metatile time according to how much CPU usage on tile.osm.org is spent on each zoom level, the speedup is probably more like ~10% to PostgreSQL but this is just an estimate (again see https://github.com/mapnik/mapnik/pull/4578 for what I mean by that reweighting), and of course Mapnik time is unchanged by this.