### PR TITLE
Defer ST_PointOnSurface until after conditions are met, reduce Postgres time by ~20%

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1383,7 +1383,7 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            CASE WHEN is_polygon THEN ST_PointOnSurface(way) ELSE way END AS way,
+            way,
             name,
             ref,
             railway,
@@ -1391,7 +1391,7 @@ Layer:
             station
           FROM
           (SELECT
-              way, TRUE AS is_polygon,
+              ST_PointOnSurface(way) AS way,
               name,
               ref,
               railway,
@@ -1404,13 +1404,13 @@ Layer:
               AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
           UNION ALL
           SELECT
-              way, FALSE AS is_polygon,
+              way,
               name,
               ref,
               railway,
               aerialway,
               tags->'station' AS station,
-              NULL::float as way_area,
+              NULL::real AS way_area,
               osm_id
             FROM planet_osm_point
             WHERE way && !bbox!
@@ -1581,7 +1581,7 @@ Layer:
             *
           FROM
           (SELECT -- This subselect allows filtering on the feature column
-              CASE WHEN is_polygon THEN ST_PointOnSurface(way) ELSE way END AS way,
+              CASE WHEN way_area IS NOT NULL THEN ST_PointOnSurface(way) ELSE way END AS way,
               CASE
                 WHEN amenity = 'parcel_locker'
                 THEN CONCAT_WS(E'\n', COALESCE(tags->'brand', tags->'operator', name), ref)
@@ -1732,7 +1732,7 @@ Layer:
               osm_id
             FROM
               (SELECT
-                  way, TRUE AS is_polygon,
+                  way,
                   name,
                   access,
                   aeroway,
@@ -1762,7 +1762,7 @@ Layer:
                   AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
               UNION ALL
               SELECT
-                  way, FALSE AS is_polygon,
+                  way,
                   name,
                   access,
                   aeroway,
@@ -1785,7 +1785,7 @@ Layer:
                   tourism,
                   waterway,
                   tags,
-                  NULL::float AS way_area,
+                  NULL::real AS way_area,
                   osm_id
                 FROM planet_osm_point
                 WHERE way && !bbox!
@@ -2370,7 +2370,7 @@ Layer:
                   man_made,
                   railway,
                   tags,
-                  NULL::float AS way_area
+                  NULL::real AS way_area
                 FROM planet_osm_point
                 WHERE way && !bbox!
               ) _

--- a/project.mml
+++ b/project.mml
@@ -1383,7 +1383,7 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            CASE WHEN is_polygon THEN ST_PointOnSurface(way) ELSE way END AS way,
             name,
             ref,
             railway,
@@ -1391,7 +1391,7 @@ Layer:
             station
           FROM
           (SELECT
-              ST_PointOnSurface(way) AS way,
+              way, TRUE AS is_polygon,
               name,
               ref,
               railway,
@@ -1404,7 +1404,7 @@ Layer:
               AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
           UNION ALL
           SELECT
-              way,
+              way, FALSE AS is_polygon,
               name,
               ref,
               railway,
@@ -1581,7 +1581,7 @@ Layer:
             *
           FROM
           (SELECT -- This subselect allows filtering on the feature column
-              way,
+              CASE WHEN is_polygon THEN ST_PointOnSurface(way) ELSE way END AS way,
               CASE
                 WHEN amenity = 'parcel_locker'
                 THEN CONCAT_WS(E'\n', COALESCE(tags->'brand', tags->'operator', name), ref)
@@ -1732,7 +1732,7 @@ Layer:
               osm_id
             FROM
               (SELECT
-                  ST_PointOnSurface(way) AS way,
+                  way, TRUE AS is_polygon,
                   name,
                   access,
                   aeroway,
@@ -1762,7 +1762,7 @@ Layer:
                   AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
               UNION ALL
               SELECT
-                  way,
+                  way, FALSE AS is_polygon,
                   name,
                   access,
                   aeroway,


### PR DESCRIPTION
`ST_PointOnSurface` takes about 1.6 microseconds. Currently, it is called for every polygon that touches the `!bbox!` by the `amenity-points` layer (and then again by `text-point`), and by `stations`. This happens **before** we filter based on tags for what is actually a visible amenity point.

This PR simply defers the `ST_PointOnSurface` call to the outermost nested query, so it only runs on the polygons that met the conditions.

Starting from a measurement base of including #5297 and #5285 (for the added index), my test suite of 42 metatiles goes from 274 total seconds of Postgres CPU time to 217 seconds, a reduction of 20.8% (for all queries, not just these two). When I do a weighted average according to how much CPU time tile.osm.org spends on each zoom level, the reduction is less, more like 11.7%. (see https://github.com/mapnik/mapnik/pull/4578 for what I mean by that reweighting and the 42 metatiles).

The savings of about 57 seconds is because there are about 36 million calls to `ST_PointOnSurface` avoided (13.28 million for `amenity-points` then repeated for `text-point` then another 9 million for `stations`). The actual number of polygon stations across these 42 metatiles that make it to the new location of `ST_PointOnSurface` goes down to just 27.

(context: I am working on performance because tile.osm.org is 'nearing capacity', see https://github.com/openstreetmap/operations/issues/1343 and https://github.com/openstreetmap/operations/issues/1375)