### PR TITLE
Prevent housenumber line break

### DIFF
--- a/functions.sql
+++ b/functions.sql
@@ -145,7 +145,10 @@ BEGIN
   IF found_sep IS NOT NULL THEN
     parts := string_to_array(listtext, found_sep);
     IF array_length(parts, 1) > 2 THEN
-      RETURN parts[1] || chr(x'2026'::int) || parts[array_length(parts, 1)];
+      RETURN parts[1]
+          || chr(x'2026'::int) -- U+2026 HORIZONTAL ELLIPSIS: …
+          || chr(x'2060'::int) -- U+2060 WORD JOINER: Prevents a linebreak. Without this, it might render as: 123…\n456
+          || parts[array_length(parts, 1)];
     END IF;
   END IF;
 


### PR DESCRIPTION
Context: https://github.com/openstreetmap-carto/openstreetmap-carto/pull/5272#issuecomment-5580660583

Changes proposed in this pull request:
- Add the `U+2060 WORD JOINER` after the `…` in a house number to prevent the possibility of

```
1234…
5678
```

Now it is forced to always be:

```
1234…5678
```

https://en.wikipedia.org/wiki/Word_joiner

The joiner isn't needed prior to the ellipsis because of [this rule](https://www.unicode.org/reports/tr14/#LB22). After the ellipsis is not protected so the WJ as you'd expect [prohibits it](https://www.unicode.org/reports/tr14/#WJ). The other chars don't allow breaking on either side. Semicolon and comma because of [here](https://www.unicode.org/reports/tr14/#LB15d) and [here](https://www.unicode.org/reports/tr14/#LB25). And hyphen because of [here](https://www.unicode.org/reports/tr14/#LB21) and [here](https://www.unicode.org/reports/tr14/#LB18). I wrongly thought in [my last comment](https://github.com/openstreetmap-carto/openstreetmap-carto/pull/5272#issuecomment-5580660583) that the space was non breaking, now I realize that that was actually separating `addr:housenumber` from `addr:unit`. A space [does](https://www.unicode.org/reports/tr14/#LB18) allow breaking.

[`#19/37.76566/-122.45417`](https://www.openstreetmap.org/#map=19/37.765660/-122.454170)

<!--
https://kosmtik.leijurv.com/openstreetmap-carto/export/?showExtent=true&format=png&width=400&height=568&scale=1&zoom=19&bounds=-122.45489269495013%2C37.76490515988178%2C-122.45381981134418%2C37.76610951878697
-->
|Before|After|
|---|---|
|<img width="400" height="568" alt="download (21)" src="https://github.com/user-attachments/assets/5251d65b-e55c-4a6a-85e5-f6dd085df24b" />|<img width="400" height="568" alt="download (22)" src="https://github.com/user-attachments/assets/79541d5e-b74e-4f1c-aad8-d597cac99f98" />|




To try this change locally, run `docker compose exec -T db psql -U postgres -d gis -v ON_ERROR_STOP=1 --single-transaction < functions.sql` then `docker compose restart -t0 kosmtik`